### PR TITLE
Release 1.1.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,9 @@
 # Specify compile flags and the path to both MPI and HDF5 dynamic libraries   #
 # and headers.                                                                #
 # ----------------------------------------------------------------------------#
-VERSION_MAJOR	:= 0
-VERSION_MINOR	:= 12
-VERSION_PATCH	:= 1
+VERSION_MAJOR	:= 1
+VERSION_MINOR	:= 1
+VERSION_PATCH	:= 0
 
 AS		:= nasm
 ASFLAGS		+= -felf64 -w+all -w-reloc-rel-dword -Ox

--- a/README.md
+++ b/README.md
@@ -156,6 +156,8 @@ Documentation
 Citation
 --------
 
+If you use phase2 in published work, cite:
+
 > Marek Miller, Jakob Gunther, Freek Witteveen, Matthew S.
 > Teynor, Mihael Erakovic, Markus Reiher, Gemma C. Solomon,
 > and Matthias Christandl, *phase2: Full-State Vector

--- a/README.md
+++ b/README.md
@@ -3,47 +3,34 @@ phase2
 
 [![CI](https://github.com/Quantum-for-Life/phase2/actions/workflows/CI.yml/badge.svg?branch=main)](https://github.com/Quantum-for-Life/phase2/actions/workflows/CI.yml)
 
-Hamiltonian simulation on CPU and GPU clusters. 🏭
+Full state-vector simulation of Hamiltonian time evolution,
+targeting quantum phase estimation workflows in computational
+chemistry.  Runs on CPU and NVIDIA GPU clusters via MPI and
+HDF5; reference algorithms include 1st- and 2nd-order Trotter,
+qDRIFT, and a composite (partially randomised) integrator.
+
+Reference: arXiv:[2504.17881](https://arxiv.org/abs/2504.17881).
 
 
-Dependencies
-------------
+Install
+-------
 
-To run the simulation, you will need:
-
-- Linux x86-64 platform, GNU C library and C>=11 compiler toolchain
-- [OpenMPI][openmpi-website]
-- Parallel [HDF5][hdf5-website]
-
-Assuming we're on Ubuntu 22.04 or later, you can install the dependencies with:
-
-```bash
-sudo apt install gcc
-sudo apt install libopenmpi-dev openmpi-common
-sudo apt install libhdf5-dev hdf5-tools libhdf5-mpi-dev libhdf5-openmpi-dev
-```
-
-If you want to run the simulation on Euler cluster (ETHZ), just load these
-modules:
+Build dependencies on Ubuntu 22.04 or later:
 
 ```bash
-ml load stack/2024-06
-ml load openmpi/4.1.6
-ml load hdf5/1.14.3
-ml load python/3.11.6
-ml load curl/8.4.0-s6dtj75
-ml load libszip/2.1.1-gz5ijo3
-ml load zlib/1.3-mktm5vz
+sudo apt install gcc libopenmpi-dev openmpi-common \
+                 libhdf5-openmpi-dev hdf5-tools
 ```
 
-[hdf5-website]: https://www.hdfgroup.org/solutions/hdf5/
-[openmpi-website]: https://www.open-mpi.org/
+On the ETH Euler cluster:
 
+```bash
+ml load stack/2024-06 openmpi/4.1.6 hdf5/1.14.3 \
+        python/3.11.6 curl/8.4.0-s6dtj75 \
+        libszip/2.1.1-gz5ijo3 zlib/1.3-mktm5vz
+```
 
-Compiling the source code
--------------------------
-
-Download and compile the source code with:
+Build:
 
 ```bash
 git clone https://github.com/Quantum-for-Life/phase2
@@ -51,39 +38,55 @@ cd phase2
 make
 ```
 
-To run the test suite:
+
+Run
+---
+
+Simulate four 1st-order Trotter steps on the water
+CAS(5,6) test fixture, on two MPI ranks:
 
 ```bash
-make check
+mpirun -n 2 ./ph2run/ph2run -S test/data/H2O_CAS56.h5 \
+       trott -D 0.1 -s 4
 ```
 
-Individual tests can be found in `./test` directory. The compiled applications
-are MPI-aware and can be run in a distributed mode with `mpirun` as well:
+Results land in the `/circ_trott` group of the same HDF5
+file.  Other subcommands — `trott2`, `qdrift`, `cmpsit` —
+share the same `-S FILE` convention; see
+`./ph2run/ph2run --help` and `./ph2run/ph2run CMD --help`
+for the flag surface.
 
-```bash
-make check-mpi
-```
+The MPI rank count must be a power of two and must not
+exceed `2^(nqb-1)`, where `nqb` is the qubit width of the
+register.  Set `PHASE2_LOG` to one of `trace`, `debug`,
+`info`, `warn`, `error`, `fatal` to control log verbosity.
 
-You can specify the number of MPI processes with `MPIRANKS=n` like this:
 
-```bash
-make check-mpi MPIRANKS=16
-```
+State preparation contract
+--------------------------
 
-The default value is `MPIRANKS=2`. This number *must be a power of two*
-and must not exceed the number of cores available.
+`simul.h5` carries exactly one initial-state encoding under
+`/state_prep`:
 
-The system can be configured to use the simulator library
-[QuEST](https://github.com/QuEST-Kit/QuEST) as a backend, instead of the
-internal engine.  Make sure QuEST is compiled in the `DISTRIBUTED` mode.
-Consult [Makefile](./Makefile) for how to configure the build system.
+- `/state_prep/multidet` — explicit list of (bitstring,
+  complex amplitude) pairs.
+- `/state_prep/coeff_matrix` — real `(n_sites, n_occ)`
+  molecular-orbital coefficient matrix.  The simulator
+  expands it on the fly via Slater-Condon, scattering
+  amplitudes directly into the MPI-distributed register.
+  Supports closed/open shell, Z₂ + S_z tapering, and CSF
+  superpositions.
 
-You can also use the software to perform distributed GPU simulation.  You
-will need a CUDA-aware MPI implementation on your system.  Follow 
-[this tutorial](https://github.com/Quantum-for-Life/cuda-aware-mpi-cluster)
-to see how to set up a CUDA-aware MPI cluster.
+The file is rejected at open time if both subgroups are
+present, or if neither is.  See
+[doc/simul-h5-specs.md](doc/simul-h5-specs.md) for the full
+schema, dispatch rules, and tapering convention.
 
-To use GPUs instead of CPUs, recompile the sources:
+
+GPU build
+---------
+
+Build against CUDA-aware OpenMPI:
 
 ```bash
 make clean
@@ -91,61 +94,16 @@ make BACKEND=cuda
 make BACKEND=cuda check
 ```
 
-The software assumes there is one GPU per MPI process available on local nodes.
-
-On Euler, load the `cuda` module along with those specified above:
-
-```bash
-ml load cuda/12.1.1
-```
+Requires one GPU per MPI process and a CUDA-aware MPI
+installation.  Override `CUDA_PREFIX` if the toolkit lives
+outside `/usr/local/cuda`.
 
 
-How to use it
--------------
+Python
+------
 
-Prepare an input file for the simulation according to the
-[specification](doc/simul-h5-specs.md). Then run:
-
-```bash
-mpirun -n [NUM_CPUS] ./ph2run/ph2run -S [SIMUL_FILE] trott -s [NUM_STEPS]
-```
-
-or
-
-```bash
-mpirun -n [NUM_CPUS] ./ph2run/ph2run -S [SIMUL_FILE] qdrift -d [DEPTH] -n [SAMPLES]
-```
-
-where
-
-- `NUM_CPUS` is the `mpirun` option specifying the number of processes to
-  run. This must be a power of 2.
-- `SIMUL_FILE` is the path to the simulation file in the HDF5 format
-  (default: `./simul.h5`).
-- `NUM_STEPS` is an integer number of Trotter steps.
-
-Available subcommands: `trott`, `qdrift`, `cmpsit`.  Run
-`./ph2run/ph2run CMD --help` for subcommand-specific options.
-
-Optionally, you can specify the level of log messages for the program to report,
-by setting `PHASE2_LOG` environment variable to be one of: `trace`,
-`debug`, `info`, `warn`, `error`, `fatal`. E.g.,
-
-```bash
-mpirun -n 8 -x PHASE2_LOG=info ./ph2run/ph2run -S simul.h5 trott -s 100
-```
-
-will compute 100 Trotter steps for a Hamiltonian specified in the file
-`simul.h5` using 8 MPI processes, and write the result back to the same file.
-
-See also the directory: [./simul](./simul) for an example of a simple
-automated system.
-
-
-Python interface
-----------------
-
-Build the shared library and install the Python package:
+`phase2` ships a thin Python wrapper around a single
+overlap-evaluation entry point:
 
 ```bash
 make shared
@@ -154,91 +112,60 @@ source .venv/bin/activate
 pip install -e ".[test]"
 ```
 
-Run the example:
-
-```bash
-python examples/pauli_rotation.py
-```
-
-Run the test suite:
-
-```bash
-pytest -v
-```
-
-Use from Python:
-
 ```python
 import phase2
 r = phase2.run(["X0", "Z1"], [0.3, -0.2], 1.0, "00")
 ```
 
-With MPI (number of ranks must be a power of two, and
-must not exceed half the number of amplitudes):
+With MPI (ranks must be a power of two and at most half the
+number of amplitudes):
 
 ```bash
 mpirun -n 4 python examples/pauli_rotation.py
 ```
 
 See [doc/python.md](doc/python.md) for the full API
-reference, Pauli string format, MPI usage, and examples.
+reference and limitations.
 
 
-Input contract
---------------
+Tests and benchmarks
+--------------------
 
-The `simul.h5` input file now supports two mutually
-exclusive state-prep subtypes:
+```bash
+make check                 # full C test suite
+make check-mpi MPIRANKS=4  # same, under MPI
+make check-python          # cross-check coeff_matrix expansion
+make bench                 # paulis and qreg micro-benchmarks
+make test-asan             # ASan + UBSan build
+make test-valgrind         # leak/UB check via valgrind
+```
 
-- `/state_prep/multidet/` — flat list of (bitstring,
-  amplitude) pairs.  Default for small `M`.
-- `/state_prep/coeff_matrix/` — a real `n_sites x n_occ`
-  coefficient matrix.  The simulator runs a Slater-Condon
-  expansion at `circ_prepst()` time and scatters directly
-  into the MPI-distributed register.  For trial states
-  whose dense form `M` would otherwise be too large to
-  ship on disk.
+Test fixtures live in `test/data/`.
 
-Exactly one subgroup must be present; the file is rejected
-at open time otherwise.  See
-[doc/simul-h5-specs.md](doc/simul-h5-specs.md) for both
-schema and expansion algorithm.
 
 Documentation
 -------------
 
-- [doc/phase2.md](doc/phase2.md) — comprehensive reference
-  covering design rationale, computational kernels (CPU and
-  CUDA), algorithms (Trotter, qDRIFT, composite), full API
-  reference, and build instructions.
-- [doc/python.md](doc/python.md) — Python interface:
-  installation, API, examples, MPI usage.
+- [doc/phase2.md](doc/phase2.md) — reference manual:
+  design, kernels (CPU and CUDA), algorithms, API, build.
+- [doc/python.md](doc/python.md) — Python interface.
 - [doc/simul-h5-specs.md](doc/simul-h5-specs.md) — HDF5
-  simulation file format specification.
+  input/output schema.
 
 
-Credits and License
--------------------
+Citation
+--------
 
-This software is distributed under the BSD 3-Clause License. See [LICENSE](./LICENSE)
-for more information.
-
-Online repository available at: https://github.com/Quantum-for-Life/phase2
-
-
-### Citation
-
-Please cite this work as:
-
-> Marek Miller, Jakob Gunther, Freek Witteveen, Matthew S. Teynor, Mihael Erakovic,
-> Markus Reiher, Gemma C. Solomon, and Matthias Christandl,
-> *phase2: Full-State Vector Simulation of Quantum Time Evolution at Scale*, arXiv preprint, arXiv:2504.17881.
+> Marek Miller, Jakob Gunther, Freek Witteveen, Matthew S.
+> Teynor, Mihael Erakovic, Markus Reiher, Gemma C. Solomon,
+> and Matthias Christandl, *phase2: Full-State Vector
+> Simulation of Quantum Time Evolution at Scale*,
+> arXiv:2504.17881.
 
 
-### Maintainers
+Maintainer & licence
+--------------------
 
-* Marek Miller <mlm@math.ku.dk>
-
-Report bugs or submit patches via [GitHub Issues].
-
-[GitHub Issues]: https://github.com/Quantum-for-Life/phase2/issues
+Marek Miller <mlm@math.ku.dk>.  BSD 3-Clause — see
+[LICENSE](./LICENSE).  Report bugs and submit patches via
+[GitHub Issues](https://github.com/Quantum-for-Life/phase2/issues).

--- a/doc/phase2.md
+++ b/doc/phase2.md
@@ -446,39 +446,48 @@ scaling.
 
 ### 6.2 Subcommands
 
-#### `trott` -- First-order Trotter
+#### `trott` -- 1st-order Trotter
 
     ph2run [OPTS] trott [TROTT_OPTS]
 
 | Flag    | Description                          | Default |
 |---------|--------------------------------------|---------|
-| `-D VAL`| Rotation angle delta                 | 1.0     |
+| `-D VAL`| Trotter step size (delta)            | 1.0     |
 | `-s N`  | Number of Trotter steps              | 1       |
 
-#### `qdrift` -- qDRIFT randomised algorithm
+#### `trott2` -- 2nd-order symmetric (Strang) Trotter
+
+    ph2run [OPTS] trott2 [TROTT2_OPTS]
+
+| Flag    | Description                          | Default |
+|---------|--------------------------------------|---------|
+| `-D VAL`| Trotter step size (delta)            | 1.0     |
+| `-s N`  | Number of Trotter steps              | 1       |
+
+#### `qdrift` -- qDRIFT randomised product formula
 
     ph2run [OPTS] qdrift [QDRIFT_OPTS]
 
 | Flag    | Description                          | Default |
 |---------|--------------------------------------|---------|
-| `-D VAL`| Step size parameter                  | 1.0     |
-| `-d VAL`| Random depth (terms per sample)      | 64      |
+| `-D VAL`| qDRIFT step size                     | 1.0     |
+| `-d N`  | Randomised terms per sample          | 64      |
 | `-n N`  | Number of independent samples        | 1       |
-| `-x N`  | PRNG seed (must be nonzero)          | 1       |
+| `-x N`  | PRNG seed (must be non-zero)         | 1       |
 
-#### `cmpsit` -- Composite (2nd-order, partially random)
+#### `cmpsit` -- Composite (2nd-order, partially randomised)
 
     ph2run [OPTS] cmpsit [CMPSIT_OPTS]
 
 | Flag    | Description                          | Default |
 |---------|--------------------------------------|---------|
-| `-l VAL`| Deterministic length (top-L terms)   | 1       |
-| `-d VAL`| Random depth                         | 64      |
+| `-l N`  | Number of deterministic top-|c_k|    | 1       |
+| `-d N`  | Randomised terms per step            | 64      |
 | `-s N`  | Number of Trotter steps              | 1       |
-| `-D VAL`| Deterministic angle (angle_det)      | 1.0     |
-| `-R VAL`| Randomised angle (angle_rand)        | 1.0     |
+| `-D VAL`| Deterministic step size (angle_det)  | 1.0     |
+| `-R VAL`| Randomised step size (angle_rand)    | 1.0     |
 | `-n N`  | Number of independent samples        | 1       |
-| `-x N`  | PRNG seed (must be nonzero)          | 1       |
+| `-x N`  | PRNG seed (must be non-zero)         | 1       |
 
 ### 6.3 Environment Variables
 
@@ -492,32 +501,53 @@ emitted.
 
 ## 7. Examples
 
-The test suite includes two HDF5 data files:
+The test suite includes several HDF5 input files:
 
-- `test/data/H2O_CAS56.h5`: Water molecule in a CAS(5,6)
-  active space, 10 qubits, 251 Hamiltonian terms,
-  1 determinant.
-- `test/data/case-d9f603dc.h5_solved`: Small 3-qubit test
-  case, 10 terms, 3 determinants.
+- `test/data/H2O_CAS56.h5`: water in a CAS(5,6) active space,
+  10 qubits, 251 Hamiltonian terms, single-determinant
+  reference (`/state_prep/multidet`).
+- `test/data/case-d9f603dc.h5_solved`: 3-qubit toy case,
+  10 terms, 3 determinants.
+- `test/data/N4_closed.h5`: 8-qubit, n_sites=4, closed-shell
+  reference encoded as `/state_prep/coeff_matrix` — exercises
+  the Slater-Condon expansion path.
+- `test/data/bendazzoli/n4_oss_k0/n4_oss_k0.h5`: open-shell
+  CSF superposition (two-component) used by the
+  `t-ref-bendazzoli` reference test.
 
-### 7.1 Trotter simulation (4 steps, 2 MPI ranks)
+### 7.1 Trotter (4 steps, 2 MPI ranks)
 
     mpirun -n 2 ./ph2run/ph2run -S test/data/H2O_CAS56.h5 \
         trott -D 0.1 -s 4
 
-### 7.2 qDRIFT simulation (64 depth, 100 samples)
+### 7.2 Symmetric (Strang) Trotter
+
+    mpirun -n 2 ./ph2run/ph2run -S test/data/H2O_CAS56.h5 \
+        trott2 -D 0.1 -s 4
+
+### 7.3 qDRIFT (depth 64, 100 samples)
 
     mpirun -n 2 ./ph2run/ph2run -S test/data/H2O_CAS56.h5 \
         qdrift -D 0.05 -d 64 -n 100 -x 42
 
-### 7.3 Composite simulation (2nd-order Trotter)
+### 7.4 Composite (2nd-order)
 
     mpirun -n 2 ./ph2run/ph2run                            \
-        -S test/data/case-d9f603dc.h5_solved                \
+        -S test/data/case-d9f603dc.h5_solved               \
         cmpsit -l 3 -d 32 -s 4 -D 0.1 -R 0.05 -n 50 -x 7
 
-All three commands write results back into the respective
-HDF5 groups in the simulation file.
+### 7.5 Coefficient-matrix state prep
+
+    mpirun -n 2 ./ph2run/ph2run -S test/data/N4_closed.h5 \
+        trott -D 0.05 -s 8
+
+The reference state is reconstructed at `circ_prepst` time
+from `/state_prep/coeff_matrix`; no per-determinant
+amplitudes appear in the file (see §3 of
+`doc/simul-h5-specs.md`).
+
+All commands write results back into the respective HDF5
+groups in the simulation file.
 
 ---
 
@@ -1291,7 +1321,31 @@ Write results to the `/circ_trott` group in the HDF5 file.
 
 ---
 
-### 8.8 qDRIFT (`include/circ/qdrift.h`)
+### 8.8 Symmetric Trotter (`include/circ/trott2.h`)
+
+Strang 2nd-order product formula.  One step is a forward
+sweep at `delta/2` followed by a reverse sweep at
+`delta/2`, both expressed through `circ_step` /
+`circ_step_reverse`.
+
+```c
+struct trott2_data { double delta; size_t steps; };
+struct trott2 { struct circ ct; struct trott2_data dt; };
+
+int  trott2_init(struct trott2 *t2,
+        const struct trott2_data *dt, data_id fid);
+void trott2_free(struct trott2 *t2);
+int  trott2_simul(struct trott2 *t2);
+int  trott2_write_res(struct trott2 *t2, data_id fid);
+```
+
+Behaviour mirrors `trott_*` with results written to
+`/circ_trott2`.  See `include/circ/trott2.h` for the
+per-function contract.
+
+---
+
+### 8.9 qDRIFT (`include/circ/qdrift.h`)
 
 ```c
 struct qdrift_data {
@@ -1353,7 +1407,7 @@ file.
 
 ---
 
-### 8.9 Composite (`include/circ/cmpsit.h`)
+### 8.10 Composite (`include/circ/cmpsit.h`)
 
 ```c
 struct cmpsit_data {
@@ -1430,18 +1484,30 @@ structure is fully specified in
 
 Key groups:
 
-- `/state_prep/multidet`: initial state as a
+- `/state_prep/multidet`: initial state as an explicit
   multideterminant expansion (complex coefficients and
   Slater determinants).
+- `/state_prep/coeff_matrix`: initial state as a real
+  `(n_sites, n_occ)` molecular-orbital coefficient matrix.
+  The simulator expands it to a dense superposition at
+  `circ_prepst` time via the Slater-Condon formula.
+  Supports `closed_shell`, `tapered`, and an optional
+  `csf/` subgroup for CSF superpositions.
+- Exactly one of `/state_prep/multidet` or
+  `/state_prep/coeff_matrix` must be present; the
+  dispatch table is documented in
+  [doc/simul-h5-specs.md](simul-h5-specs.md).
 - `/pauli_hamil`: Hamiltonian as a list of real
   coefficients and Pauli strings, with a normalisation
   factor.
-- `/circ_trott`: Trotter simulation results (delta
+- `/circ_trott`: 1st-order Trotter results (delta
   attribute and complex-valued output).
-- `/circ_qdrift`: qDRIFT simulation results (step_size,
-  depth, seed attributes and complex-valued output).
-- `/circ_cmpsit`: Composite simulation results (length,
-  depth, angle_det, angle_rand, steps, seed attributes and
+- `/circ_trott2`: symmetric (Strang) 2nd-order Trotter
+  results (delta attribute and complex-valued output).
+- `/circ_qdrift`: qDRIFT results (step_size, depth,
+  num_samples, seed attributes and complex-valued output).
+- `/circ_cmpsit`: composite results (length, depth,
+  angle_det, angle_rand, steps, seed attributes and
   complex-valued output).
 
 Pauli operators in HDF5 datasets use the standard encoding:
@@ -1495,22 +1561,32 @@ runtime flags can be passed via `MPIFLAGS`:
 
 ### 10.4 Test Suite Overview
 
-The test suite consists of 12 test programs:
+The C test binaries live in `test/` and follow the prefix
+convention `t-<area>[_<aspect>]`:
 
-| Test               | Module tested                    |
-|--------------------|----------------------------------|
-| `t-paulis`         | Pauli string encoding/decoding   |
-| `t-qreg`           | Quantum register init/get/set    |
-| `t-world`          | World init/free lifecycle        |
-| `t-data_open`      | HDF5 file open/close             |
-| `t-data_attr`      | HDF5 attribute read/write        |
-| `t-data_hamil`     | Hamiltonian loading from HDF5    |
-| `t-data_multidet`  | Multidet state loading from HDF5 |
-| `t-data_trott_steps` | Trotter step data I/O          |
-| `t-prob`           | CDF construction and inversion   |
-| `t-circ`           | Circuit infrastructure           |
-| `t-circ_cache`     | Cache batching logic             |
-| `t-circ_trott`     | End-to-end Trotter simulation    |
+| Area              | Coverage                                |
+|-------------------|-----------------------------------------|
+| `t-paulis`        | Pauli string encoding and arithmetic    |
+| `t-qreg`, `t-bitstring_index` | quantum register layout, MPI ownership |
+| `t-world`         | global init / free lifecycle            |
+| `t-data_*`        | HDF5 attr, hamil, multidet, coeff_matrix, trott-step I/O |
+| `t-prob`          | CDF construction and inversion          |
+| `t-combinations`, `t-det_small` | enumerator and determinant primitives |
+| `t-circ`, `t-circ_cache`        | circuit infrastructure and cache batching |
+| `t-circ_trott`, `t-circ_trott2` | end-to-end Trotter / Strang Trotter |
+| `t-circ_trott_coeff`, `t-circ_trott2_coeff` | same, on coeff_matrix inputs |
+| `t-circ_prepst_coeff`           | Slater-Condon state-prep dispatch |
+| `t-state_prep_coeff_*`          | expand, CSF superposition, large reference |
+| `t-ref-bendazzoli`              | precomputed CSF amplitudes reference |
 
-Test data files reside in `test/data/`.  Tests are built
-with `-DDEBUG -g -Og` flags.
+The Python harness `test/t-ref-coeff_matrix.py` cross-checks
+the C expansion against an in-tree reference oracle in
+`test/ref/coeff_matrix_reference.py`; it is run by
+`make check-python`.
+
+Test data files reside in `test/data/`.  The slow test
+`t-state_prep_coeff_large` is built and run separately via
+`make build-test-slow` / `make check-slow`.  Sanitiser and
+valgrind variants are available as `make test-asan`,
+`make test-valgrind`, `make test-mpi-asan`.  Tests are
+built with `-DDEBUG -g -Og` flags.

--- a/doc/phase2.md
+++ b/doc/phase2.md
@@ -3,7 +3,7 @@
 Full-state vector quantum Hamiltonian simulation library for
 quantum phase estimation.
 
-Version 0.12.1
+Version 1.1.0
 
 Copyright (c) 2025, Marek Miller.  BSD 3-Clause License.
 

--- a/doc/simul-h5-specs.md
+++ b/doc/simul-h5-specs.md
@@ -120,7 +120,7 @@ The simulator probes both `/state_prep/multidet` and
 | absent | absent | error: no state-prep subgroup found |
 | present | absent | path: `STPREP_MULTIDET` |
 | absent | present | path: `STPREP_COEFF_MATRIX` |
-| present | present | error: ambiguous; rebuild pak |
+| present | present | error: ambiguous; rebuild `simul.h5` |
 
 `STPREP_MULTIDET` and `STPREP_COEFF_MATRIX` are the enum
 values from `enum stprep_kind` in `phase2/include/phase2/data.h`.
@@ -233,7 +233,9 @@ formula:
   S_2(δ) = ∏_{k=1..K} exp(-i h_k δ/2) · ∏_{k=K..1} exp(-i h_k δ/2)
 
 Each step applies one forward sweep at `δ/2` followed by one
-reverse sweep at `δ/2` over the same Hamiltonian terms.
+reverse sweep at `δ/2` over the same Hamiltonian terms.  See
+`circ/trott2.c` for the implementation and `doc/phase2.md §5`
+for the algorithm description.
 
 - Attribute: `delta`
     - *Type*: `double`
@@ -268,7 +270,46 @@ reverse sweep at `δ/2` over the same Hamiltonian terms.
     - *Shape*: `(NUM_SAMPLES, 2)`
     - *Comment*: Columns specify the real (column 1) and imaginary (column 2)
       part of a complex number.
-  
+
+## Group: `/circ_cmpsit`
+
+Output of the composite (partially randomised) 2nd-order
+Trotter algorithm.  The Hamiltonian is split into a
+deterministic top-`length` part applied lexicographically
+and a randomised qDRIFT-style part of `depth` rotations per
+step.  See `circ/cmpsit.c` and `doc/phase2.md §5` for the
+algorithm description.
+
+- Attribute: `length`
+    - *Type*: `unsigned long`
+    - *Comment*: Number of deterministic top-|c_k| terms.
+
+- Attribute: `depth`
+    - *Type*: `unsigned long`
+    - *Comment*: Number of randomised terms drawn per step.
+
+- Attribute: `angle_det`
+    - *Type*: `double`
+    - *Comment*: Step size for the deterministic part.
+
+- Attribute: `angle_rand`
+    - *Type*: `double`
+    - *Comment*: Step size for the randomised part.
+
+- Attribute: `steps`
+    - *Type*: `unsigned long`
+    - *Comment*: Number of composite Trotter steps per sample.
+
+- Attribute: `seed`
+    - *Type*: `unsigned long`
+    - *Comment*: PRNG seed used for this run; non-zero.
+
+- Dataset: `values`
+    - *Type*: `double`
+    - *Shape*: `(NUM_SAMPLES, 2)`
+    - *Comment*: Columns specify the real (column 1) and
+      imaginary (column 2) part of a complex number.
+
 [hdf5-data-types]: https://docs.hdfgroup.org/hdf5/v1_14/predefined_datatypes_tables.html
 
 [uuid-rfc]: https://datatracker.ietf.org/doc/html/rfc4122

--- a/include/circ/cmpsit.h
+++ b/include/circ/cmpsit.h
@@ -6,17 +6,36 @@
 #include "phase2.h"
 #include "xoshiro256ss.h"
 
+/*
+ * Composite (partially randomised) 2nd-order Trotter.
+ *
+ * The Hamiltonian is split into two disjoint parts:
+ *
+ *   - deterministic: the top `length` terms by |c_k|,
+ *     sorted lexicographically and applied with step size
+ *     `angle_det`;
+ *   - randomised: the remaining terms, sampled qDRIFT-style
+ *     with step size `angle_rand` to `depth` rotations.
+ *
+ * One step applies a forward half-sweep of one composite
+ * sample at omega = 0.5, then a reverse half-sweep of an
+ * independent sample — yielding the symmetric S_2 integrator.
+ *
+ * Output is the per-sample overlap series written to
+ * /circ_cmpsit/values.  `seed` must be non-zero.
+ */
+
 struct cmpsit_data {
-	uint64_t seed;
-	size_t length;
-	size_t depth;
-	size_t steps;
-	double angle_det;
-	double angle_rand;
-	size_t samples;
+	uint64_t seed;		/* PRNG seed; must be non-zero */
+	size_t length;		/* deterministic term count */
+	size_t depth;		/* randomised term count per step */
+	size_t steps;		/* number of Trotter steps */
+	double angle_det;	/* deterministic step size */
+	double angle_rand;	/* randomised step size */
+	size_t samples;		/* number of independent samples */
 };
 
-/* Sampled circuit. */
+/* Working state for one sampled composite circuit. */
 struct cmpsit_ranct {
 	struct circ_hamil hm_det, hm_ran, hm_smpl;
 	struct prob_cdf cdf;
@@ -32,12 +51,23 @@ struct cmpsit {
 	struct xoshiro256ss rng;
 };
 
+/* Load the Hamiltonian and initial state, split into
+ * deterministic / randomised parts, sort the deterministic
+ * part lexicographically, build the randomised CDF, seed the
+ * PRNG.  Returns 0 on success, -1 on error. */
 int cmpsit_init(struct cmpsit *cp, const struct cmpsit_data *dt, data_id fid);
 
+/* Release all resources held by `cp`. */
 void cmpsit_free(struct cmpsit *cp);
 
+/* Run `dt.samples` independent samples of `dt.steps` steps
+ * and store per-sample overlaps in `ct.vals`.  Returns 0 on
+ * success, -1 on error. */
 int cmpsit_simul(struct cmpsit *cp);
 
+/* Write length, depth, angle_det, angle_rand, steps, seed
+ * attributes and the overlap series to /circ_cmpsit.
+ * Returns 0 on success, -1 on error. */
 int cmpsit_write_res(struct cmpsit *cp, data_id fid);
 
 #endif // CMPSIT_H

--- a/include/circ/qdrift.h
+++ b/include/circ/qdrift.h
@@ -8,15 +8,32 @@
 #include "phase2/prob.h"
 #include "xoshiro256ss.h"
 
+/*
+ * qDRIFT randomised product formula (Campbell, 2019).
+ *
+ * For each of `samples` independent runs, draw `depth`
+ * Hamiltonian terms i.i.d. from the probability distribution
+ * p_k = |c_k| / sum_j |c_j| and apply
+ *
+ *   exp(i * asin(step_size) * sign(c_k) * P_k)
+ *
+ * in draw order.  Output is the per-sample overlap
+ * <psi|U|psi>, written to /circ_qdrift/values.
+ *
+ * The PRNG is xoshiro256** seeded by `seed` and split
+ * deterministically across MPI ranks; `seed` must be
+ * non-zero.
+ */
+
 struct qdrift_data {
-	size_t depth;
-	size_t samples;
-	double step_size;
-	uint64_t seed;
+	size_t depth;		/* terms drawn per sample */
+	size_t samples;		/* number of independent samples */
+	double step_size;	/* qDRIFT step size */
+	uint64_t seed;		/* PRNG seed; must be non-zero */
 };
 
 struct qdrift_ranct {
-	struct circ_hamil hm_ran; /* randomized */
+	struct circ_hamil hm_ran;
 	struct prob_cdf cdf;
 };
 
@@ -27,12 +44,21 @@ struct qdrift {
 	struct xoshiro256ss rng;
 };
 
+/* Load Hamiltonian and initial state, build the |c_k| CDF,
+ * seed the PRNG.  Returns 0 on success, -1 on error. */
 int qdrift_init(struct qdrift *qd, const struct qdrift_data *dt, data_id fid);
 
+/* Release all resources held by `qd`. */
 void qdrift_free(struct qdrift *qd);
 
+/* Run `dt.samples` independent samples of depth `dt.depth`
+ * and store per-sample overlaps in `ct.vals`.  Returns 0 on
+ * success, -1 on error. */
 int qdrift_simul(struct qdrift *qd);
 
+/* Write step_size, depth, num_samples, seed attributes and
+ * the overlap series to /circ_qdrift.  Returns 0 on success,
+ * -1 on error. */
 int qdrift_write_res(struct qdrift *qd, data_id fid);
 
 #endif // QDRIFT_H

--- a/include/circ/trott.h
+++ b/include/circ/trott.h
@@ -4,14 +4,20 @@
 #include "phase2/circ.h"
 #include "phase2/data.h"
 
-struct trott_data {
-	double delta;
-	size_t steps;
-};
+/*
+ * 1st-order Lie-Trotter product formula:
+ *
+ *   T_1(delta) = prod_{k=1..K} exp(-i h_k delta)
+ *
+ * One step applies all Hamiltonian terms once in
+ * lexicographic order.  Output is the overlap
+ * <psi| T_1(delta)^s |psi> for s = 1..steps,
+ * written to /circ_trott/values.
+ */
 
-struct trott_steps {
-	_Complex double *z;
-	size_t len;
+struct trott_data {
+	double delta;	/* step size */
+	size_t steps;	/* number of Trotter steps */
 };
 
 struct trott {
@@ -19,12 +25,20 @@ struct trott {
 	struct trott_data dt;
 };
 
+/* Load Hamiltonian and initial state from `fid`, allocate
+ * the register, sort the Hamiltonian lexicographically.
+ * Returns 0 on success, -1 on error. */
 int trott_init(struct trott *tt, const struct trott_data *dt, data_id fid);
 
+/* Release all resources held by `tt`. */
 void trott_free(struct trott *tt);
 
+/* Run `dt.steps` Trotter steps and store overlaps in
+ * `ct.vals`.  Returns 0 on success, -1 on error. */
 int trott_simul(struct trott *tt);
 
+/* Write `delta` attribute and overlap series to the
+ * /circ_trott group.  Returns 0 on success, -1 on error. */
 int trott_write_res(struct trott *tt, data_id fid);
 
 #endif // TROTT_H

--- a/include/circ/trott2.h
+++ b/include/circ/trott2.h
@@ -10,14 +10,16 @@
  *   S_2(delta) = prod_{k=1..K} exp(-i h_k delta/2)
  *              * prod_{k=K..1} exp(-i h_k delta/2)
  *
- * One full step is forward sweep at delta/2 followed by
- * reverse sweep at delta/2 — both implemented via existing
- * circ_step / circ_step_reverse primitives.
+ * One full step is a forward sweep at delta/2 followed by a
+ * reverse sweep at delta/2 — both implemented via the
+ * existing circ_step / circ_step_reverse primitives.  Output
+ * is the overlap <psi| S_2(delta)^s |psi> for s = 1..steps,
+ * written to /circ_trott2/values.
  */
 
 struct trott2_data {
-	double delta;
-	size_t steps;
+	double delta;	/* step size */
+	size_t steps;	/* number of Trotter steps */
 };
 
 struct trott2 {
@@ -25,12 +27,20 @@ struct trott2 {
 	struct trott2_data dt;
 };
 
+/* Load Hamiltonian and initial state from `fid`, allocate
+ * the register, sort the Hamiltonian lexicographically.
+ * Returns 0 on success, -1 on error. */
 int trott2_init(struct trott2 *t2, const struct trott2_data *dt, data_id fid);
 
+/* Release all resources held by `t2`. */
 void trott2_free(struct trott2 *t2);
 
+/* Run `dt.steps` symmetric Trotter steps and store overlaps
+ * in `ct.vals`.  Returns 0 on success, -1 on error. */
 int trott2_simul(struct trott2 *t2);
 
+/* Write `delta` attribute and overlap series to the
+ * /circ_trott2 group.  Returns 0 on success, -1 on error. */
 int trott2_write_res(struct trott2 *t2, data_id fid);
 
 #endif // TROTT2_H

--- a/include/phase2/data.h
+++ b/include/phase2/data.h
@@ -185,7 +185,7 @@ enum stprep_kind {
  *  absent   | absent       | -ENOENT
  *  present  | absent       | STPREP_MULTIDET
  *  absent   | present      | STPREP_COEFF_MATRIX
- *  present  | present      | -EINVAL  (ambiguous; rebuild pak)
+ *  present  | present      | -EINVAL  (ambiguous; rebuild simul.h5)
  *
  * On success *out holds the selected kind and the function
  * returns 0.  On failure *out is unchanged and the function

--- a/ph2run/ph2run.c
+++ b/ph2run/ph2run.c
@@ -41,11 +41,12 @@ const char *argp_program_version = PHASE2_VERSION;
 const char *argp_program_bug_address = "Marek Miller <mlm@math.ku.dk>";
 
 #define doc                                                                    \
-	"Run phase2 sumilations.  CMD can be one of the algorithms:\n"         \
-	"  trott\n"                                                            \
-	"  qdrift\n"                                                           \
-	"  cmpsit\n"                                                           \
-	"\nRun CMD --help for more information"
+	"Run phase2 simulations.  CMD can be one of the algorithms:\n"         \
+	"  trott    1st-order Trotter product formula\n"                       \
+	"  trott2   2nd-order symmetric (Strang) Trotter\n"                    \
+	"  qdrift   qDRIFT randomised product formula\n"                       \
+	"  cmpsit   composite (deterministic + randomised, 2nd order)\n"       \
+	"\nRun CMD --help for more information."
 #define args_doc "CMD [CMD_OPT]"
 
 static struct args {
@@ -167,7 +168,7 @@ static int cmd_trott_run(void *data)
 	return trott_simul(&dt->tt);
 }
 
-#define doc_trott "Run deterministic Trotter product formula (1st order)."
+#define doc_trott "Run 1st-order Trotter product formula."
 #define argv0_trott "ph2run [OPTS] trott"
 #define args_doc_trott ""
 
@@ -176,8 +177,9 @@ static struct trott_data *const args_trott = &cmd_trott_dt.tt_dt;
 
 static struct argp_option opts_trott[] = {
 	{ "delta", 'D', "VAL", 0,
-		"Rotation angle, a floating point number (default: 1.0)", 0 },
-	{ "steps", 's', "N", 0, "Number of Trotter steps", 0 },
+		"Trotter step size (default: 1.0)", 0 },
+	{ "steps", 's', "N", 0,
+		"Number of Trotter steps (default: 1)", 0 },
 	{ 0 }
 };
 
@@ -274,7 +276,7 @@ static int cmd_trott2_run(void *data)
 	return trott2_simul(&dt->t2);
 }
 
-#define doc_trott2 "Run deterministic Trotter product formula (2nd order, Strang)."
+#define doc_trott2 "Run 2nd-order symmetric (Strang) Trotter product formula."
 #define argv0_trott2 "ph2run [OPTS] trott2"
 #define args_doc_trott2 ""
 
@@ -282,8 +284,9 @@ static struct trott2_data *const args_trott2 = &cmd_trott2_dt.t2_dt;
 
 static struct argp_option opts_trott2[] = {
 	{ "delta", 'D', "VAL", 0,
-		"Rotation angle, a floating point number (default: 1.0)", 0 },
-	{ "steps", 's', "N", 0, "Number of Trotter steps", 0 },
+		"Trotter step size (default: 1.0)", 0 },
+	{ "steps", 's', "N", 0,
+		"Number of Trotter steps (default: 1)", 0 },
 	{ 0 }
 };
 
@@ -349,8 +352,8 @@ static int cmd_qdrift_init(data_id fid, void *data)
 {
 	struct cmd_qdrift_dt *const dt = data;
 
-	log_info("*** Circuit: qDRIFT >>> ***");
-	log_info("delta: %f", dt->qd_dt.step_size);
+	log_info("*** Circuit: qdrift ***");
+	log_info("step_size: %f", dt->qd_dt.step_size);
 	log_info("depth: %zu", dt->qd_dt.depth);
 	log_info("samples: %zu", dt->qd_dt.samples);
 	log_info("seed: %lu", dt->qd_dt.seed);
@@ -383,21 +386,21 @@ static int cmd_qdrift_run(void *data)
 	return qdrift_simul(&dt->qd);
 }
 
-#define doc_qdrift "Run qDRIFT randomized algorithm."
+#define doc_qdrift "Run qDRIFT randomised product formula."
 #define argv0_qdrift "ph2run [OPTS] qdrift"
 #define args_doc_qdrift ""
 
 static struct qdrift_data *const args_qdrift = &cmd_qdrift_dt.qd_dt;
 
 static struct argp_option opts_qdrift[] = {
-	{ "delta", 'D', "VAL", 0,
-		"Rotation angle, a floating point number (default: 1.0)", 0 },
-	{ "depth", 'd', "VAL", 0, "Random depth (default: 64)", 0 },
-	{ "samples", 'n', "N", 0, "Number of independent samples (default: 1)",
-		0 },
+	{ "step-size", 'D', "VAL", 0,
+		"qDRIFT step size (default: 1.0)", 0 },
+	{ "depth", 'd', "N", 0,
+		"Number of randomised terms per sample (default: 64)", 0 },
+	{ "samples", 'n', "N", 0,
+		"Number of independent samples (default: 1)", 0 },
 	{ "seed", 'x', "N", 0,
-		"Seed of the pseudo random number generator (default: 1, must differ from zero)",
-		0 },
+		"PRNG seed; must be non-zero (default: 1)", 0 },
 	{ 0 }
 };
 
@@ -517,26 +520,27 @@ static int cmd_cmpsit_run(void *data)
 }
 
 #define doc_cmpsit                                                             \
-	"Run composite algorithm (partially randomized), 2nd order Trotter."
+	"Run composite (partially randomised) 2nd-order Trotter."
 #define argv0_cmpsit "ph2run [OPTS] cmpsit"
 #define args_doc_cmpsit ""
 
 static struct cmpsit_data *const args_cmpsit = &cmd_cmpsit_dt.cp_dt;
 
 static struct argp_option opts_cmpsit[] = {
-	{ "length", 'l', "VAL", 0, "Deterministic legth (default: 1)", 0 },
-	{ "depth", 'd', "VAL", 0, "Random depth (default: 64)", 0 },
-	{ "steps", 's', "N", 0, "Number of Trotter steps (default: 1)", 0 },
+	{ "length", 'l', "N", 0,
+		"Number of deterministic top-|c_k| terms (default: 1)", 0 },
+	{ "depth", 'd', "N", 0,
+		"Number of randomised terms per step (default: 64)", 0 },
+	{ "steps", 's', "N", 0,
+		"Number of Trotter steps (default: 1)", 0 },
 	{ "angle-det", 'D', "VAL", 0,
-		"Deterministic angle, a floating point number (default: 1.0)", 0 },
+		"Step size for the deterministic part (default: 1.0)", 0 },
 	{ "angle-rand", 'R', "VAL", 0,
-		"Angle for the randomized part, a floating point number (default: 1.0)",
-		0 },
-	{ "samples", 'n', "N", 0, "Number of independent samples (default: 1)",
-		0 },
+		"Step size for the randomised part (default: 1.0)", 0 },
+	{ "samples", 'n', "N", 0,
+		"Number of independent samples (default: 1)", 0 },
 	{ "seed", 'x', "N", 0,
-		"Seed of the pseudo random number generator (default: 1, must differ from zero)",
-		0 },
+		"PRNG seed; must be non-zero (default: 1)", 0 },
 	{ 0 }
 };
 

--- a/phase2/data.c
+++ b/phase2/data.c
@@ -439,8 +439,8 @@ int data_state_prep_kind(const data_id fid, enum stprep_kind *out)
 		fprintf(stderr,
 			"simul.h5: ambiguous state prep (both "
 			"/state_prep/multidet and "
-			"/state_prep/coeff_matrix present); rebuild pak "
-			"with exactly one\n");
+			"/state_prep/coeff_matrix present); "
+			"rebuild simul.h5 with exactly one\n");
 		return -EINVAL;
 	}
 	if (!has_md && !has_cm) {

--- a/phase2/state_prep_coeff.c
+++ b/phase2/state_prep_coeff.c
@@ -1,33 +1,7 @@
 /*
- * state_prep_coeff - Slater-Condon expansion of a coefficient-
- * matrix trial state into a dense MPI-distributed register.
- *
- * Public API:
- *   int state_prep_coeff_expand(...)
- *   int state_prep_coeff_expand_all(...)
- *   int circ_coeff_init(...)
- *   void circ_coeff_free(...)
- *
- * The expansion walks all (occ_alpha, occ_beta) k-subsets in
- * lex order, precomputes the determinant tables det_alpha[i]
- * and det_beta[j], then runs the outer product.  Each MPI rank
- * does the full outer-product walk but only writes amplitudes
- * it owns (ownership filter via qreg_getihi).
- *
- * Bitstring convention:
- *   * alpha qubits live in bits [0, n_sites)
- *   * beta  qubits live in bits [n_sites, 2*n_sites)
- *   * occ_alpha[i] = q sets bit q
- *   * occ_beta [j] = q sets bit n_sites + q
- *
- * For tapered states (tapered != 0) bits 0 and n_sites are
- * dropped after the bitstring is constructed; the upper bits
- * are shifted down by two.  The dispatcher carries the original
- * untapered C matrices end-to-end; the drop happens at scatter
- * time per generated bitstring.
- *
- * Sparsity prune: amplitudes with |c| < SPARSITY_PRUNE are
- * skipped.
+ * Slater-Condon expansion of a coefficient-matrix trial
+ * state.  See include/phase2/state_prep_coeff.h for the
+ * public API contract; this file holds the implementation.
  */
 
 #include "c23_compat.h"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "phase2"
-version = "1.0.0"
+version = "1.1.0"
 description = "Python interface to the phase2 MPI Hamiltonian simulator"
 license = "BSD-3-Clause"
 requires-python = ">=3.10"

--- a/simul/README.md
+++ b/simul/README.md
@@ -13,10 +13,12 @@ pip install h5py qiskit-nature pyscf
 
 # How to use it
 
-1. Make sure `ph2run-trott` is compiled in `../build`
-   (see [../README.md](../README.md) on how to compile the sources).
-2. Put `FCIDUMP` file in this directory (with exactly this name).
-3. Put `INPUTST` file in the same directory.
+1. Make sure `ph2run` is compiled at `../ph2run/ph2run`
+   (see [../README.md](../README.md) on how to compile the
+   sources).
+2. Put an `FCIDUMP` file in this directory (with exactly
+   this name).
+3. Put an `INPUTST` file in the same directory.
 4. Run:
 
 ```
@@ -27,26 +29,24 @@ or modify `Makefile` to your liking.
 
 # `INPUTST` (input state) file format
 
-*TODO: This section should be moved to `../doc` and merge with the rest of
-the documentation.*
-
-The format of the `INPUTST` file is pretty basic. Each line specifies one
-state (Slater determinant) of a covex linear combination:
+The format of the `INPUTST` file is plain text.  Each line
+specifies one Slater determinant of a convex linear
+combination:
 
 ```text
 F F I I I ... I
 ```
 
-where `F` stands for a floating point number and `I` is either `0` or `1`.  
-The two floating point numbers together denote real and imaginary part of a
-complex coefficient in the linear combination. The integer numbers `I I ..
-I` denote the occupation of electron orbitals. By convention, the *alpha*
-and *gamma* type of orbitals interleave:
+where `F` is a floating-point number and `I` is either `0`
+or `1`.  The two floats give the real and imaginary part of
+the complex coefficient in the linear combination.  The
+integers `I I ... I` denote occupation of spin orbitals.
+By convention, the *alpha* and *beta* type orbitals
+interleave:
 
 ```latex
-I_{1,\alpha} I_{1, \beta} I_{2,\alpha} I_{2, \beta} etc. 
+I_{1,\alpha} I_{1, \beta} I_{2,\alpha} I_{2, \beta} etc.
 ```
 
-The number of integer values `I I ... I` must be the same for all rows.
-
-Whitespace and empty lines are ignored.
+The number of integer values `I I ... I` must be the same
+for all rows.  Whitespace and empty lines are ignored.


### PR DESCRIPTION
## Summary

Cuts the next release after `v1.0`.  Bundles the
documentation, CLI, and packaging cleanup that had been
pending alongside the feature work merged since the tag.

## Changes since v1.0

### Algorithms and core engine
- **trott2** — symmetric (Strang) 2nd-order Trotter product
  formula, implemented atop `circ_step` / `circ_step_reverse`
  (`3676947`, `d6670f4`).
- **coeff_matrix state prep** — `/state_prep/coeff_matrix`
  input subtype with on-the-fly Slater-Condon expansion into
  the MPI-distributed register; supports closed/open shell,
  Z₂ + S_z tapering, and a `csf/` superposition subgroup
  (`59bd2ad`, `58682f7`, `af90df0`).
- **det_small + combinations** utilities moved to `lib/` for
  reuse (`f89983e`, `58682f7`).

### Python interface
- New `phase2` Python package wrapping the C entry point
  `phase2_run` via ctypes; single public function
  `phase2.run(paulis, coeffs, delta, psi) -> complex`
  (`8720c08`, `58a6cd8`, `5e805ad`).
- `doc/python.md` reference (`e44f95c`, `fd867cd`); CI
  runs the Python suite (`b2e2dd4`, `4606a6e`).

### Documentation and CLI (this branch)
- `ph2run --help`: typos fixed (sumilations, legth), banner
  normalised, `trott2` advertised in the top-level CMD list,
  qdrift `--delta` renamed to `--step-size` to match the
  HDF5 attribute the value actually controls.
- `doc/phase2.md`: trott2 subcommand block, examples for
  trott2 and coeff_matrix, API entry for `circ/trott2.h`,
  current test-suite summary, coeff_matrix and trott2
  entries in §9.
- `doc/simul-h5-specs.md`: `/circ_cmpsit` schema (was
  missing), `/circ_trott2` cross-links, drop the
  "rebuild pak" colloquialism.
- `doc/state-prep.md` and stray external-project references
  retired (`f75ef10`).
- `simul/README.md`: orbital convention (alpha/beta, not
  gamma), current binary path, typo fixes.
- `README.md` rewritten top-down for 1.1.0; citation block
  preserved with restored lead-in.
- Public circ/*.h headers gain per-function contracts;
  unused `struct trott_steps` removed.
- `data.c` error message and `data.h` dispatch-table prose
  use `simul.h5` consistently.

### Packaging
- `phase2: release 1.1.0` — synchronise Makefile,
  `pyproject.toml`, and `doc/phase2.md` to **1.1.0**.
  Latest tag was `v1.0`; the Makefile and `pyproject.toml`
  had drifted apart (0.12.1 vs 1.0.0).

## Test plan

- [x] `make distclean && make build build-test`
- [x] `make check` — full C test suite passes
- [x] `./ph2run/ph2run --version` → `1.1.0`
- [x] `./ph2run/ph2run --help` lists four subcommands
- [x] `./ph2run/ph2run qdrift --help` shows `--step-size`
- [ ] `make check-mpi MPIRANKS=2` (verify on CI)
- [ ] `make check-python` (verify on CI; local env lacks h5py)
- [ ] CUDA build smoke test on GPU runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)