### PR TITLE
Logging: rewrite + coverage + policy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -282,6 +282,8 @@ TESTS		:= $(TESTDIR)/t-bitstring_index			\
 			$(TESTDIR)/t-data_open				\
 			$(TESTDIR)/t-data_trott_steps			\
 			$(TESTDIR)/t-det_small				\
+			$(TESTDIR)/t-log				\
+			$(TESTDIR)/t-log_release			\
 			$(TESTDIR)/t-paulis				\
 			$(TESTDIR)/t-prob				\
 			$(TESTDIR)/t-qreg				\
@@ -307,7 +309,16 @@ build-test: $(TESTS)
 CHECKS	:= $(TESTS:$(TESTDIR)/%=check/%)
 
 .PHONY: $(CHECKS)
+# Tests are always built with -DDEBUG so log_trace / log_debug
+# in include/log.h expand to real emits.  t-log_release
+# below cancels this so the release-build strip of
+# trace/debug macros can be verified end-to-end -- the
+# override must come after the blanket -DDEBUG so the
+# trailing -UDEBUG wins on the gcc command line.
+$(TESTS): CFLAGS += -DDEBUG -g -Og
 $(CHECKS): CFLAGS += -DDEBUG -g -Og
+$(TESTDIR)/t-log_release: CFLAGS += -UDEBUG
+check/t-log_release: CFLAGS += -UDEBUG
 $(CHECKS): check/%: $(TESTDIR)/%
 	@./$< && echo "$< OK" || (echo "$<: FAIL"; exit 1)
 

--- a/README.md
+++ b/README.md
@@ -58,8 +58,11 @@ for the flag surface.
 
 The MPI rank count must be a power of two and must not
 exceed `2^(nqb-1)`, where `nqb` is the qubit width of the
-register.  Set `PHASE2_LOG` to one of `trace`, `debug`,
-`info`, `warn`, `error`, `fatal` to control log verbosity.
+register.  Default log verbosity is `info` on stdout;
+raise with `PHASE2_LOG=debug` (requires `make debug` for
+trace/debug to compile in), enable per-rank logging in
+distributed runs with `PHASE2_LOG_ALL=1`.  See
+[doc/logging.md](doc/logging.md) for the full reference.
 
 
 State preparation contract
@@ -148,6 +151,8 @@ Documentation
 
 - [doc/phase2.md](doc/phase2.md) — reference manual:
   design, kernels (CPU and CUDA), algorithms, API, build.
+- [doc/logging.md](doc/logging.md) — logging subsystem:
+  format, levels, env vars, MPI, policy for new code.
 - [doc/python.md](doc/python.md) — Python interface.
 - [doc/simul-h5-specs.md](doc/simul-h5-specs.md) — HDF5
   input/output schema.

--- a/bench/b-paulis.c
+++ b/bench/b-paulis.c
@@ -1,3 +1,5 @@
+#define LOG_SUBSYS "bench"
+
 #include "c23_compat.h"
 #include <stdint.h>
 

--- a/bench/b-qreg.c
+++ b/bench/b-qreg.c
@@ -1,3 +1,5 @@
+#define LOG_SUBSYS "bench"
+
 #include "c23_compat.h"
 #include <complex.h>
 #include <stdint.h>

--- a/bench/b-qreg.c
+++ b/bench/b-qreg.c
@@ -120,8 +120,8 @@ static void measure_b_qreg_zero(void)
 		q.reg = &reg;
 
 		bench_mark(&b, REPS_MAX, b_qreg_zero, &q);
-		log_info("b_qreg_zero [nqb,t_ms]: %2u,%11.6f", n,
-			bench_msrep(b));
+		log_info("b_qreg_zero [nqb,t_ms]: %2lu,%11.6f",
+			(unsigned long)n, bench_msrep(b));
 
 		qreg_free(&reg);
 	}
@@ -191,8 +191,8 @@ static void measure_b_qreg_paulirot(void)
 
 			bench_mark(&b, REPS_MAX, b_qreg_paulirot, &q);
 			log_info("b_qreg_paulirot [nqb,ncodes,t_ms]: "
-				 "%2u,%3u,%11.6f",
-				n, ncodes, bench_msrep(b));
+				 "%2lu,%3zu,%11.6f",
+				(unsigned long)n, ncodes, bench_msrep(b));
 
 			b_qreg_paulirot_destroy(&q);
 			qreg_free(&reg);

--- a/circ/cmpsit.c
+++ b/circ/cmpsit.c
@@ -5,6 +5,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#define LOG_SUBSYS "cmpsit"
 #include "log.h"
 #include "phase2.h"
 #include "xoshiro256ss.h"

--- a/circ/cmpsit.c
+++ b/circ/cmpsit.c
@@ -103,11 +103,11 @@ static int ranct_init(struct cmpsit_ranct *rct, const struct circ_hamil *hm,
 		goto err_cdf;
 
 	ranct_calc_cdf(rct, hm_tmp.terms + dt->length);
-	log_info("ranct.lambda_r: %.9f", rct->lambda_r);
+	log_debug("ranct.lambda_r: %.9f", rct->lambda_r);
 	rct->depth = dt->depth;
-	log_info("ranct.depth: %zu", rct->depth);
+	log_debug("ranct.depth: %zu", rct->depth);
 	rct->angle_rand = dt->angle_rand;
-	log_info("ranct.tau: %.9f", rct->angle_rand);
+	log_debug("ranct.tau: %.9f", rct->angle_rand);
 
 	circ_hamil_free(&hm_tmp);
 
@@ -221,22 +221,41 @@ int cmpsit_simul(struct cmpsit *cp)
 	struct circ *ct = &cp->ct;
 	struct circ_values *vals = &ct->vals;
 
+	log_debug("simul: samples=%zu steps=%zu length=%zu depth=%zu"
+		  " angle_det=%g angle_rand=%g",
+		vals->len, cp->dt.steps, cp->dt.length, cp->dt.depth,
+		cp->dt.angle_det, cp->dt.angle_rand);
+
 	struct circ_prog prog;
 	circ_prog_init(&prog, vals->len);
 	for (size_t i = 0; i < vals->len; i++) {
+		log_debug("sample %zu/%zu", i + 1, vals->len);
 		circ_prepst(ct);
 		for (size_t s = 0; s < cp->dt.steps; s++) {
-			if (hm_sample(cp) < 0)
+			log_trace("step %zu/%zu fwd half-sweep", s + 1,
+				cp->dt.steps);
+			if (hm_sample(cp) < 0) {
+				log_error("simul: hm_sample failed");
 				return -1;
-			if (circ_step(&cp->ct, &cp->ranct.hm_smpl, 0.5) < 0)
+			}
+			if (circ_step(&cp->ct, &cp->ranct.hm_smpl, 0.5) < 0) {
+				log_error("simul: fwd circ_step failed");
 				return -1;
+			}
 			ranct_hmsmpl_free(cp);
 
-			if (hm_sample(cp) < 0)
+			log_trace("step %zu/%zu rev half-sweep", s + 1,
+				cp->dt.steps);
+			if (hm_sample(cp) < 0) {
+				log_error("simul: hm_sample failed");
 				return -1;
+			}
 			if (circ_step_reverse(
-				    &cp->ct, &cp->ranct.hm_smpl, 0.5) < 0)
+				    &cp->ct, &cp->ranct.hm_smpl, 0.5) < 0) {
+				log_error("simul: rev circ_step_reverse"
+					  " failed");
 				return -1;
+			}
 			ranct_hmsmpl_free(cp);
 		}
 		vals->z[i] = circ_measure(ct);

--- a/circ/cmpsit.c
+++ b/circ/cmpsit.c
@@ -227,7 +227,7 @@ int cmpsit_simul(struct cmpsit *cp)
 		cp->dt.angle_det, cp->dt.angle_rand);
 
 	struct circ_prog prog;
-	circ_prog_init(&prog, vals->len);
+	circ_prog_init(&prog, vals->len, "sample");
 	for (size_t i = 0; i < vals->len; i++) {
 		log_debug("sample %zu/%zu", i + 1, vals->len);
 		circ_prepst(ct);
@@ -260,6 +260,7 @@ int cmpsit_simul(struct cmpsit *cp)
 		}
 		vals->z[i] = circ_measure(ct);
 		circ_prog_tick(&prog);
+		circ_prog_emit(&prog, LOG_SUBSYS);
 	}
 
 	return 0;

--- a/circ/qdrift.c
+++ b/circ/qdrift.c
@@ -1,3 +1,5 @@
+#define LOG_SUBSYS "qdrift"
+
 #include "c23_compat.h"
 #include <complex.h>
 #include <float.h>
@@ -7,6 +9,7 @@
 #include <stdlib.h>
 
 #include "container_of.h"
+#include "log.h"
 #include "phase2.h"
 #include "xoshiro256ss.h"
 
@@ -105,15 +108,23 @@ int qdrift_simul(struct qdrift *qd)
 	struct circ *ct = &qd->ct;
 	struct circ_values *vals = &ct->vals;
 
+	log_debug("simul: samples=%zu depth=%zu step_size=%g seed=%lu"
+		  " cdf_len=%zu",
+		vals->len, qd->dt.depth, qd->dt.step_size,
+		(unsigned long)qd->dt.seed, qd->ranct.cdf.len);
+
 	struct circ_prog prog;
 	circ_prog_init(&prog, vals->len);
 	for (size_t i = 0; i < vals->len; i++) {
+		log_debug("sample %zu/%zu", i + 1, vals->len);
 		circ_prepst(ct);
 
 		ranct_sample(qd);
 		if (circ_step(ct, &qd->ranct.hm_ran, asin(qd->dt.step_size)) <
-			0)
+			0) {
+			log_error("simul: circ_step failed at sample %zu", i);
 			return -1;
+		}
 		vals->z[i] = circ_measure(ct);
 
 		circ_prog_tick(&prog);

--- a/circ/qdrift.c
+++ b/circ/qdrift.c
@@ -114,7 +114,7 @@ int qdrift_simul(struct qdrift *qd)
 		(unsigned long)qd->dt.seed, qd->ranct.cdf.len);
 
 	struct circ_prog prog;
-	circ_prog_init(&prog, vals->len);
+	circ_prog_init(&prog, vals->len, "sample");
 	for (size_t i = 0; i < vals->len; i++) {
 		log_debug("sample %zu/%zu", i + 1, vals->len);
 		circ_prepst(ct);
@@ -128,6 +128,7 @@ int qdrift_simul(struct qdrift *qd)
 		vals->z[i] = circ_measure(ct);
 
 		circ_prog_tick(&prog);
+		circ_prog_emit(&prog, LOG_SUBSYS);
 	}
 
 	return 0;

--- a/circ/trott.c
+++ b/circ/trott.c
@@ -1,22 +1,28 @@
+#define LOG_SUBSYS "trott"
+
 #include "c23_compat.h"
 #include <complex.h>
 #include <math.h>
 #include <stdint.h>
 #include <stdlib.h>
 
+#include "log.h"
 #include "phase2.h"
 
 #include "circ/trott.h"
 
 int trott_init(struct trott *tt, const struct trott_data *dt, const data_id fid)
 {
-	if (circ_init(&tt->ct, fid, dt->steps) < 0)
+	if (circ_init(&tt->ct, fid, dt->steps) < 0) {
+		log_error("trott_init: circ_init failed");
 		return -1;
+	}
 
 	tt->dt = *dt;
 
 	circ_hamil_sort_lex(&tt->ct.hm);
 
+	log_debug("trott_init: delta=%g steps=%zu", dt->delta, dt->steps);
 	return 0;
 }
 
@@ -35,8 +41,11 @@ int trott_simul(struct trott *tt)
 
 	circ_prepst(ct);
 	for (size_t i = 0; i < vals->len; i++) {
-		if (circ_step(ct, &ct->hm, tt->dt.delta) < 0)
+		log_debug("step %zu/%zu", i + 1, vals->len);
+		if (circ_step(ct, &ct->hm, tt->dt.delta) < 0) {
+			log_error("trott_simul: step %zu failed", i);
 			return -1;
+		}
 		vals->z[i] = circ_measure(ct);
 
 		circ_prog_tick(&prog);

--- a/circ/trott.c
+++ b/circ/trott.c
@@ -37,7 +37,7 @@ int trott_simul(struct trott *tt)
 	struct circ_values *vals = &ct->vals;
 
 	struct circ_prog prog;
-	circ_prog_init(&prog, vals->len);
+	circ_prog_init(&prog, vals->len, "step");
 
 	circ_prepst(ct);
 	for (size_t i = 0; i < vals->len; i++) {
@@ -49,6 +49,7 @@ int trott_simul(struct trott *tt)
 		vals->z[i] = circ_measure(ct);
 
 		circ_prog_tick(&prog);
+		circ_prog_emit(&prog, LOG_SUBSYS);
 	}
 
 	return 0;

--- a/circ/trott2.c
+++ b/circ/trott2.c
@@ -1,22 +1,28 @@
+#define LOG_SUBSYS "trott2"
+
 #include "c23_compat.h"
 #include <complex.h>
 #include <math.h>
 #include <stdint.h>
 #include <stdlib.h>
 
+#include "log.h"
 #include "phase2.h"
 
 #include "circ/trott2.h"
 
 int trott2_init(struct trott2 *t2, const struct trott2_data *dt, const data_id fid)
 {
-	if (circ_init(&t2->ct, fid, dt->steps) < 0)
+	if (circ_init(&t2->ct, fid, dt->steps) < 0) {
+		log_error("trott2_init: circ_init failed");
 		return -1;
+	}
 
 	t2->dt = *dt;
 
 	circ_hamil_sort_lex(&t2->ct.hm);
 
+	log_debug("trott2_init: delta=%g steps=%zu", dt->delta, dt->steps);
 	return 0;
 }
 
@@ -37,10 +43,18 @@ int trott2_simul(struct trott2 *t2)
 
 	circ_prepst(ct);
 	for (size_t i = 0; i < vals->len; i++) {
-		if (circ_step(ct, &ct->hm, half) < 0)
+		log_debug("step %zu/%zu fwd", i + 1, vals->len);
+		if (circ_step(ct, &ct->hm, half) < 0) {
+			log_error("trott2_simul: fwd sweep failed at step %zu",
+				i);
 			return -1;
-		if (circ_step_reverse(ct, &ct->hm, half) < 0)
+		}
+		log_debug("step %zu/%zu rev", i + 1, vals->len);
+		if (circ_step_reverse(ct, &ct->hm, half) < 0) {
+			log_error("trott2_simul: rev sweep failed at step %zu",
+				i);
 			return -1;
+		}
 		vals->z[i] = circ_measure(ct);
 
 		circ_prog_tick(&prog);

--- a/circ/trott2.c
+++ b/circ/trott2.c
@@ -37,7 +37,7 @@ int trott2_simul(struct trott2 *t2)
 	struct circ_values *vals = &ct->vals;
 
 	struct circ_prog prog;
-	circ_prog_init(&prog, vals->len);
+	circ_prog_init(&prog, vals->len, "step");
 
 	const double half = t2->dt.delta / 2.0;
 
@@ -58,6 +58,7 @@ int trott2_simul(struct trott2 *t2)
 		vals->z[i] = circ_measure(ct);
 
 		circ_prog_tick(&prog);
+		circ_prog_emit(&prog, LOG_SUBSYS);
 	}
 
 	return 0;

--- a/doc/logging.md
+++ b/doc/logging.md
@@ -43,7 +43,7 @@ right one from the table:
 | fatal  | anywhere       | about to `exit` / `abort` | anything recoverable   |
 
 Full guidance on what counts as "batch boundary" vs
-"per-amplitude" lives in §8 below.
+"per-amplitude" lives in §7 below.
 
 The phase2 library reports mostly **below** info; ph2run
 reports mostly **at** info.  Algorithm files in `circ/`
@@ -148,47 +148,7 @@ the dedicated `test/t-log_release` binary cancels this
 with a trailing `-UDEBUG` to verify the strip.
 
 
-## 7. Performance and volume
-
-Filtered-out fast path (release build of an info-only run
-seeing a trace-level macro):
-
-| Operation                | Cost              |
-| ------------------------ | ----------------- |
-| macro expansion          | `((void)0)`       |
-| load `log_threshold`     | n/a               |
-| function call            | n/a               |
-
-In debug builds the runtime-filtered path is one extern
-load, one compare, one not-taken branch — about **1 ns**
-on a modern x86.
-
-Filtered-in path (line actually written):
-
-| Operation                | Cost              |
-| ------------------------ | ----------------- |
-| `clock_gettime`          | ~30 ns            |
-| `localtime_r`            | ~100 ns           |
-| `snprintf` x 2           | ~1 µs             |
-| `fwrite` + `fflush`      | ~5 µs (TTY)       |
-| total                    | **~5–10 µs**      |
-
-Volume guideline:
-
-| Run                      | Approx. info bytes |
-| ------------------------ | ------------------ |
-| `trott -s 100`           | ~10 KB             |
-| `trott -s 10000`         | ~1 MB              |
-| `qdrift -n 1000`         | ~100 KB            |
-
-These are guidelines, not caps.  The library never
-throttles progress.  Operators who want less output set
-`PHASE2_LOG=warn` (silences info entirely) or redirect /
-truncate at the shell level.  Future ph2run CLI flags may
-add per-N throttling; out of scope today.
-
-
-## 8. Policy for new code (mandatory)
+## 7. Policy for new code
 
 These rules apply to every patch that adds or modifies a
 function:
@@ -223,7 +183,7 @@ This policy is enforced by review until a tooling check
 (clang-tidy, pre-commit grep) lands.
 
 
-## 9. Adding logging to existing code
+## 8. Adding logging to existing code
 
 Quick recipe when editing a file that does not yet emit:
 
@@ -232,14 +192,14 @@ Quick recipe when editing a file that does not yet emit:
    if that is what the file uses).  Pick the name from
    the existing convention: directory-aligned, lowercase,
    no spaces.
-2. Identify the points that match §8 rule 1 (I/O,
+2. Identify the points that match §7 rule 1 (I/O,
    allocation, branches, failure).  Add the right level.
 3. Recompile.  GCC will reject any format-spec mismatch.
 4. Eyeball one run with `PHASE2_LOG=debug` to confirm the
    new lines have the right subsystem tag and level.
 
 
-## 10. Examples
+## 9. Examples
 
 **Small run (info, default).**
 

--- a/doc/logging.md
+++ b/doc/logging.md
@@ -1,0 +1,284 @@
+# phase2 logging
+
+Single-page reference for the logging subsystem.  Header:
+`include/log.h`.  Implementation: `lib/log.c`.  Companion
+tests: `test/t-log.c`, `test/t-log_release.c`.
+
+## 1. Quick reference
+
+```c
+#define LOG_SUBSYS "myunit"
+#include "log.h"
+
+log_trace("hot-loop event id=%llu", id);  /* compiled in only with -DDEBUG */
+log_debug("init: alpha=%u beta=%u", a, b);/* compiled in only with -DDEBUG */
+log_info ("running simulation: %zu steps", n);
+log_warn ("retrying after transient error %d", rc);
+log_error("open(%s) failed: %s", path, strerror(errno));
+log_fatal("unrecoverable: %s", reason);
+```
+
+Default output:
+
+```
+2026-05-13 14:22:11.034 INFO  [myunit] running simulation: 100 steps
+```
+
+Levels at or below INFO (`trace`/`debug`/`info`) go to
+**stdout**; `warn`/`error`/`fatal` go to **stderr**.
+
+
+## 2. Levels and policy
+
+The level determines both verbosity and routing.  Pick the
+right one from the table:
+
+| Level  | Owner          | Log this                  | Do NOT log             |
+| ------ | -------------- | ------------------------- | ---------------------- |
+| trace  | phase2/, circ/ | batch / kernel entries    | per-amplitude state    |
+| debug  | phase2/, circ/ | init, attribute reads     | already-handled events |
+| info   | ph2run/, circ/ | options, paths, progress  | per-step engine chatter|
+| warn   | anywhere       | recoverable degradation   | normal events          |
+| error  | anywhere       | failing return path       | events already caught  |
+| fatal  | anywhere       | about to `exit` / `abort` | anything recoverable   |
+
+Full guidance on what counts as "batch boundary" vs
+"per-amplitude" lives in §8 below.
+
+The phase2 library reports mostly **below** info; ph2run
+reports mostly **at** info.  Algorithm files in `circ/`
+emit info-level progress and lifecycle banners.
+
+
+## 3. Output format
+
+```
+[r=R] YYYY-MM-DD HH:MM:SS.mmm LEVEL [subsys] message
+```
+
+Field order, left to right:
+
+- **rank prefix** `[r=R]`: only when `PHASE2_LOG_ALL=1`
+  AND the calling rank is non-zero.  Rank 0 stays
+  unprefixed in every mode, so it remains the dominant
+  voice and is easy to scan with `grep -v '\[r='`.
+- **timestamp**: local time, millisecond precision via
+  `clock_gettime(CLOCK_REALTIME, ...)` +
+  `localtime_r`.
+- **level**: five-character right-padded label
+  (`TRACE`/`DEBUG`/`INFO `/`WARN `/`ERROR`/`FATAL`).
+- **subsystem tag**: per-file label, set by `#define
+  LOG_SUBSYS "<name>"` before `#include "log.h"`.
+  Defaults to `?` if missing; reviewers flag any `[?]`.
+- **message**: printf-style; format is validated by GCC
+  via `__attribute__((format(printf, …)))` on
+  `log_emit`.
+
+
+## 4. Environment variables
+
+| Variable          | Default | Accepted values                          |
+| ----------------- | ------- | ---------------------------------------- |
+| `PHASE2_LOG`      | info    | `trace`/`debug`/`info`/`warn`/`error`/`fatal` |
+| `PHASE2_LOG_ALL`  | unset   | any non-empty value enables rank > 0      |
+
+`PHASE2_LOG` is case-insensitive and only the first
+character is consulted, so `t`, `Trace`, and `TRACE`
+parse the same.
+
+Unparseable `PHASE2_LOG` values silently fall back to the
+default — same behaviour as the prior release.
+
+
+## 5. MPI semantics
+
+Rank 0 emits unconditionally.  Other ranks emit only when
+`PHASE2_LOG_ALL=1`.  When all-ranks mode is on, non-rank-0
+lines begin with `[r=<rank>] ` so the operator can
+`sort` the captured log to interleave correctly:
+
+```
+[r=0] 2026-05-13 14:22:11.034 INFO  [world] backend: qreg
+[r=2] 2026-05-13 14:22:11.041 DEBUG [qreg]  paulirot batch n=64
+[r=1] 2026-05-13 14:22:11.041 ERROR [qreg]  send timed out
+```
+
+The rank is read from `world_info()` on each emit, so the
+flag and rank are always current.
+
+**SLURM `.out` flushing.** `log_init()` calls
+`setvbuf(stdout, NULL, _IOLBF, 0)` and
+`setvbuf(stderr, NULL, _IONBF, 0)`, and the emit path
+`fflush()`es after each line.  An operator running
+`tail -f slurm-NNN.out` sees every log line as it is
+produced, not in 4 KB chunks buffered until end of run.
+
+
+## 6. Build-time gating
+
+**Release builds strip `log_trace` and `log_debug` to
+`((void)0)`.**  The header gates them on `DEBUG`:
+
+```c
+#ifdef DEBUG
+#define log_trace(...) log_at(LOG_TRACE, __VA_ARGS__)
+#define log_debug(...) log_at(LOG_DEBUG, __VA_ARGS__)
+#else
+#define log_trace(...) ((void)0)
+#define log_debug(...) ((void)0)
+#endif
+```
+
+Production binaries (`make build` / `make all`) do not
+define `DEBUG`.  Setting `PHASE2_LOG=trace` on such a
+binary has **no effect** on trace/debug emission — the
+call sites have been compiled out, no load and no branch
+remain.
+
+To trace a production-class run, rebuild with debug
+flags:
+
+```sh
+make distclean
+make debug
+```
+
+Tests always build with `-DDEBUG -g -Og` (see Makefile);
+the dedicated `test/t-log_release` binary cancels this
+with a trailing `-UDEBUG` to verify the strip.
+
+
+## 7. Performance and volume
+
+Filtered-out fast path (release build of an info-only run
+seeing a trace-level macro):
+
+| Operation                | Cost              |
+| ------------------------ | ----------------- |
+| macro expansion          | `((void)0)`       |
+| load `log_threshold`     | n/a               |
+| function call            | n/a               |
+
+In debug builds the runtime-filtered path is one extern
+load, one compare, one not-taken branch — about **1 ns**
+on a modern x86.
+
+Filtered-in path (line actually written):
+
+| Operation                | Cost              |
+| ------------------------ | ----------------- |
+| `clock_gettime`          | ~30 ns            |
+| `localtime_r`            | ~100 ns           |
+| `snprintf` x 2           | ~1 µs             |
+| `fwrite` + `fflush`      | ~5 µs (TTY)       |
+| total                    | **~5–10 µs**      |
+
+Volume guideline:
+
+| Run                      | Approx. info bytes |
+| ------------------------ | ------------------ |
+| `trott -s 100`           | ~10 KB             |
+| `trott -s 10000`         | ~1 MB              |
+| `qdrift -n 1000`         | ~100 KB            |
+
+These are guidelines, not caps.  The library never
+throttles progress.  Operators who want less output set
+`PHASE2_LOG=warn` (silences info entirely) or redirect /
+truncate at the shell level.  Future ph2run CLI flags may
+add per-N throttling; out of scope today.
+
+
+## 8. Policy for new code (mandatory)
+
+These rules apply to every patch that adds or modifies a
+function:
+
+1. **Log non-trivial work.**  Every new function that does
+   I/O, allocates a non-trivial resource, branches on
+   configuration, or can fail **must** emit at least one
+   log line.  Pick the level from §2.
+2. **No silent error returns.**  Every error-return path
+   emits `log_error` with the failing operation and the
+   context an operator needs (path, index, return code).
+   `return -1;` without a prior log_error is a review
+   blocker.
+3. **Subsystem at module entry.**  Every public entry
+   point of a new module starts with one `log_debug`
+   describing its arguments (engine layer) or
+   `log_info` describing intent (driver layer).
+4. **Tag your file.**  Every translation unit that calls
+   `log_*` must `#define LOG_SUBSYS "<name>"` immediately
+   before `#include "log.h"`.  A `[?]` in test capture is
+   a review blocker.
+5. **Never log per-amplitude.**  The release strip
+   protects performance; this rule protects readability
+   of debug captures.  Trace at the *outer* batch /
+   kernel call, never inside the amplitude `for` loop.
+6. **Format specifiers must match types.**  GCC enforces
+   this via the `format(printf, …)` attribute on
+   `log_emit`; use `<inttypes.h>` macros (`PRIu64`, etc.)
+   for fixed-width integers.
+
+This policy is enforced by review until a tooling check
+(clang-tidy, pre-commit grep) lands.
+
+
+## 9. Adding logging to existing code
+
+Quick recipe when editing a file that does not yet emit:
+
+1. Add `#define LOG_SUBSYS "<short-name>"` immediately
+   before `#include "log.h"` (or `#include "phase2.h"`
+   if that is what the file uses).  Pick the name from
+   the existing convention: directory-aligned, lowercase,
+   no spaces.
+2. Identify the points that match §8 rule 1 (I/O,
+   allocation, branches, failure).  Add the right level.
+3. Recompile.  GCC will reject any format-spec mismatch.
+4. Eyeball one run with `PHASE2_LOG=debug` to confirm the
+   new lines have the right subsystem tag and level.
+
+
+## 10. Examples
+
+**Small run (info, default).**
+
+```sh
+./ph2run/ph2run -S test/data/H2O_CAS56.h5 trott -D 0.1 -s 4
+```
+
+```
+2026-05-13 14:22:11.034 INFO  [world]  *** Init ***
+2026-05-13 14:22:11.034 INFO  [world]  World size: 1
+2026-05-13 14:22:11.034 INFO  [world]  Backend: qreg
+2026-05-13 14:22:11.034 INFO  [ph2run] subcommand: trott
+2026-05-13 14:22:11.034 INFO  [ph2run] simul file: test/data/H2O_CAS56.h5
+2026-05-13 14:22:11.038 INFO  [ph2run] *** Circuit: trott ***
+2026-05-13 14:22:11.038 INFO  [ph2run] running simulation: 4 Trotter steps
+2026-05-13 14:22:11.041 INFO  [trott]  step 1/4 (25%) elapsed 0.00s eta 0.01s
+2026-05-13 14:22:11.044 INFO  [trott]  step 2/4 (50%) elapsed 0.01s eta 0.01s
+2026-05-13 14:22:11.047 INFO  [trott]  step 3/4 (75%) elapsed 0.01s eta 0.00s
+2026-05-13 14:22:11.050 INFO  [trott]  step 4/4 (100%) elapsed 0.01s eta 0.00s
+2026-05-13 14:22:11.051 INFO  [ph2run] simulation finished in 0.013 s
+```
+
+**Debug capture (make debug build, PHASE2_LOG=debug).**
+
+```sh
+make debug
+PHASE2_LOG=debug ./ph2run/ph2run -S test/data/H2O_CAS56.h5 trott -s 4
+```
+
+Adds engine-layer DEBUG lines: `data_open`, qubit layout,
+hamil sort, per-step debug markers, cache flush counts.
+
+**Multi-rank capture (PHASE2_LOG_ALL).**
+
+```sh
+mpirun -n 4 -x PHASE2_LOG_ALL=1 -x PHASE2_LOG=info \
+    ./ph2run/ph2run -S test/data/H2O_CAS56.h5 trott -s 4
+```
+
+Rank-0 lines remain unprefixed; ranks 1-3 prefix every
+line with `[r=N] `.  Pipe to `sort -k1` for chronological
+interleaving by rank.

--- a/doc/phase2.md
+++ b/doc/phase2.md
@@ -491,11 +491,22 @@ scaling.
 
 ### 6.3 Environment Variables
 
-**`PHASE2_LOG`**: Controls the logging verbosity.  Accepted
-values (case-sensitive): `trace`, `debug`, `info`, `warn`,
-`error`, `fatal`.  The log level is read once during
-`world_init`.  Default behaviour: info-level messages are
-emitted.
+- **`PHASE2_LOG`** (`info` default): one of `trace`,
+  `debug`, `info`, `warn`, `error`, `fatal`.  Raises
+  verbosity above the default.
+- **`PHASE2_LOG_ALL`** (unset default): any non-empty
+  value opens logging on rank > 0 in MPI runs; rank > 0
+  lines are prefixed `[r=N]`.
+
+Defaults: `info`-and-below on stdout, `warn`-and-above on
+stderr, both line-buffered + flushed per emit (SLURM
+`tail -f` friendly).  Release builds strip `log_trace`
+and `log_debug` to no-ops — rebuild with `make debug` to
+trace a production-class run.
+
+See [doc/logging.md](logging.md) for the full reference
+(format, policy for new code, performance budget,
+multi-rank semantics, examples).
 
 ---
 

--- a/include/log.h
+++ b/include/log.h
@@ -1,32 +1,91 @@
 #ifndef LOG_H
 #define LOG_H
 
+/*
+ * phase2 logging.
+ *
+ * Format (left to right):
+ *
+ *   [r=R] YYYY-MM-DD HH:MM:SS.mmm LEVEL [subsys] message
+ *
+ * The rank prefix [r=R] appears only when PHASE2_LOG_ALL=1
+ * AND the calling rank is non-zero.  Rank 0 stays unprefixed
+ * in every mode.
+ *
+ * Sinks: TRACE/DEBUG/INFO go to stdout; WARN/ERROR/FATAL go
+ * to stderr.  Both are fflushed after every emit so SLURM
+ * `tail -f` shows output as it is produced.
+ *
+ * Each translation unit that emits log_* should set its own
+ * subsystem tag before including this header:
+ *
+ *   #define LOG_SUBSYS "qreg"
+ *   #include "log.h"
+ *
+ * Files without LOG_SUBSYS fall back to "?".  Reviewers
+ * should reject patches that leave that fallback in place.
+ *
+ * Build-time gating: log_trace and log_debug expand to a
+ * no-op when DEBUG is undefined (the default for `make
+ * build`).  Release binaries pay zero cost for trace/debug
+ * call sites — no load, no branch, no format string.
+ * Tests and `make debug` builds keep them.
+ */
+
 #define PHASE2_LOG_ENVVAR "PHASE2_LOG"
+#define PHASE2_LOG_ALL_ENVVAR "PHASE2_LOG_ALL"
+
+#ifndef LOG_SUBSYS
+#define LOG_SUBSYS "?"
+#endif
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 enum log_level {
-	LOG_TRACE,
-	LOG_DEBUG,
-	LOG_INFO,
-	LOG_WARN,
-	LOG_ERROR,
-	LOG_FATAL
+	LOG_TRACE = 0,
+	LOG_DEBUG = 1,
+	LOG_INFO = 2,
+	LOG_WARN = 3,
+	LOG_ERROR = 4,
+	LOG_FATAL = 5,
 };
 
-/* Call world_init() before using this. */
-void log_log(int level, const char *fmt, ...);
+/* Runtime threshold.  Set by log_init() from PHASE2_LOG.
+ * The log_at() macro reads it directly to short-circuit
+ * filtered-out calls before any function is invoked. */
+extern int log_threshold;
 
-#define log_trace(...) log_log(LOG_TRACE, __VA_ARGS__)
-#define log_debug(...) log_log(LOG_DEBUG, __VA_ARGS__)
-#define log_info(...) log_log(LOG_INFO, __VA_ARGS__)
-#define log_warn(...) log_log(LOG_WARN, __VA_ARGS__)
-#define log_error(...) log_log(LOG_ERROR, __VA_ARGS__)
-#define log_fatal(...) log_log(LOG_FATAL, __VA_ARGS__)
+void log_emit(int level, const char *subsys, const char *file, int line,
+	const char *fmt, ...) __attribute__((format(printf, 5, 6)));
 
+#define log_at(lvl, ...)                                                       \
+	do {                                                                   \
+		if (__builtin_expect((lvl) >= log_threshold, 0))               \
+			log_emit((lvl), LOG_SUBSYS, __FILE__, __LINE__,        \
+				__VA_ARGS__);                                  \
+	} while (0)
+
+#ifdef DEBUG
+#define log_trace(...) log_at(LOG_TRACE, __VA_ARGS__)
+#define log_debug(...) log_at(LOG_DEBUG, __VA_ARGS__)
+#else
+#define log_trace(...) ((void)0)
+#define log_debug(...) ((void)0)
+#endif
+#define log_info(...) log_at(LOG_INFO, __VA_ARGS__)
+#define log_warn(...) log_at(LOG_WARN, __VA_ARGS__)
+#define log_error(...) log_at(LOG_ERROR, __VA_ARGS__)
+#define log_fatal(...) log_at(LOG_FATAL, __VA_ARGS__)
+
+/* Read PHASE2_LOG and PHASE2_LOG_ALL; set stdout to
+ * line-buffered, stderr to unbuffered.  Idempotent.
+ * Returns 0 on success, -1 on error. */
 int log_init(void);
+
+/* Flush both sinks.  Safe to call without log_init(). */
+void log_fini(void);
 
 #ifdef __cplusplus
 }

--- a/include/phase2/circ.h
+++ b/include/phase2/circ.h
@@ -3,6 +3,7 @@
 
 #include <stddef.h>
 #include <stdint.h>
+#include <time.h>
 
 #include "phase2/data.h"
 #include "phase2/paulis.h"
@@ -27,8 +28,10 @@ struct circ_muldet {
 };
 
 struct circ_prog {
-	unsigned pc; /* percent */
+	unsigned pc;	/* percent of len */
 	size_t i, len;
+	struct timespec t0;	/* wall-clock start for ETA */
+	const char *unit;	/* "step", "sample"; never NULL */
 };
 
 struct circ_values {
@@ -53,8 +56,15 @@ void circ_hamil_sort_lex(struct circ_hamil *hm);
 int circ_muldet_init(struct circ_muldet *md, size_t len);
 void circ_muldet_free(struct circ_muldet *md);
 
-void circ_prog_init(struct circ_prog *prog, size_t len);
+void circ_prog_init(struct circ_prog *prog, size_t len, const char *unit);
 void circ_prog_tick(struct circ_prog *prog);
+/* Format a rich progress line and emit it at info level
+ * through the given subsystem tag:
+ *
+ *   step 17/100 (17%) elapsed 4.31s eta 21.0s
+ *
+ * Callers control cadence; the library does not throttle. */
+void circ_prog_emit(const struct circ_prog *prog, const char *subsys);
 
 int circ_values_init(struct circ_values *vals, size_t len);
 void circ_values_free(struct circ_values *vals);

--- a/lib/log.c
+++ b/lib/log.c
@@ -1,180 +1,165 @@
 /*
- * Copyright 2020 rxi
- * Copyright 2024 Marek Miller
+ * phase2 logging — implementation.
  *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to
- * deal in the Software without restriction, including without limitation the
- * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
- * sell copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
- * IN THE SOFTWARE.
+ * See include/log.h for the public surface and the format
+ * contract.  No dependencies beyond libc + POSIX time
+ * (clock_gettime, localtime_r).  MPI is consulted only via
+ * world_info() — a cheap struct copy.
  */
+
+/* clock_gettime + localtime_r need POSIX.1-2008. */
+#define _POSIX_C_SOURCE 200809L
+
+#define LOG_SUBSYS "log"
+
 #include "c23_compat.h"
 #include <stdarg.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <time.h>
 
 #include "log.h"
 #include "phase2/world.h"
 
-#define MAX_CALLBACKS (32)
+int log_threshold = LOG_INFO;
 
-struct log_event {
-	int level;
-	struct tm *time;
+#define LINE_BUF_BYTES (4096)
 
-	va_list ap;
-	const char *fmt;
-
-	void *data;
+static const char *const LEVEL_NAMES[] = {
+	"TRACE",
+	"DEBUG",
+	"INFO",
+	"WARN",
+	"ERROR",
+	"FATAL",
 };
 
-struct callback {
-	void (*fn)(struct log_event *ev);
-	void *data;
-	int level;
-};
+static struct log_state {
+	int initialized;
+	int all_ranks;
+} state = { 0, 0 };
 
-static struct {
-	void *data;
-	int level;
-	struct callback cb[MAX_CALLBACKS];
-} L;
-
-static const char *level_strings[] = { "TRACE", "DEBUG", "INFO", "WARN",
-	"ERROR", "FATAL" };
-
-const char *log_level_string(const int level)
+static int parse_level(const char *name, int *out)
 {
-	return level_strings[level];
-}
-
-int log_level_from_lowercase(enum log_level *level, const char *name)
-{
-	if (!name)
+	if (!name || !*name)
 		return -1;
-
-	int rt = 0;
 	switch (name[0]) {
 	case 't':
 	case 'T':
-		*level = LOG_TRACE;
-		break;
+		*out = LOG_TRACE;
+		return 0;
 	case 'd':
 	case 'D':
-		*level = LOG_DEBUG;
-		break;
+		*out = LOG_DEBUG;
+		return 0;
 	case 'i':
 	case 'I':
-		*level = LOG_INFO;
-		break;
+		*out = LOG_INFO;
+		return 0;
 	case 'w':
 	case 'W':
-		*level = LOG_WARN;
-		break;
+		*out = LOG_WARN;
+		return 0;
 	case 'e':
 	case 'E':
-		*level = LOG_ERROR;
-		break;
+		*out = LOG_ERROR;
+		return 0;
 	case 'f':
 	case 'F':
-		*level = LOG_FATAL;
-		break;
-	default:
-		rt = -1;
+		*out = LOG_FATAL;
+		return 0;
 	}
-
-	return rt;
-}
-
-void log_set_level(const int level)
-{
-	L.level = level;
-}
-
-int log_add_callback(
-	void (*fn)(struct log_event *ev), void *data, const int level)
-{
-	for (int i = 0; i < MAX_CALLBACKS; i++)
-		if (!L.cb[i].fn) {
-			L.cb[i] = (struct callback){ fn, data, level };
-			return 0;
-		}
-
 	return -1;
 }
 
-static void init_event(struct log_event *ev, void *data)
+void log_emit(const int level, const char *subsys, const char *file,
+	const int line, const char *fmt, ...)
 {
-	if (!ev->time) {
-		const time_t t = time(NULL);
-		ev->time = localtime(&t);
-	}
-	ev->data = data;
-}
+	(void)file;
+	(void)line;
 
-void log_vlog(const int level, const char *fmt, va_list ap)
-{
-	struct log_event ev = {
-		.fmt = fmt,
-		.level = level,
-	};
-
-	for (int i = 0; i < MAX_CALLBACKS && L.cb[i].fn; i++) {
-		const struct callback *cb = &L.cb[i];
-		if (level >= cb->level) {
-			init_event(&ev, cb->data);
-			va_copy(ev.ap, ap);
-			cb->fn(&ev);
-			va_end(ev.ap);
-		}
-	}
-}
-
-void log_log(const int level, const char *fmt, ...)
-{
-	va_list ap;
-	va_start(ap, fmt);
-	log_vlog(level, fmt, ap);
-	va_end(ap);
-}
-
-void log_callback(struct log_event *ev)
-{
 	struct world_info wd;
-	if (world_info(&wd) == WORLD_READY && wd.rank > 0)
+	const int wstat = world_info(&wd);
+	const int rank = (wstat >= 0) ? wd.rank : 0;
+
+	/* Rank gating: non-zero ranks emit only when
+	 * PHASE2_LOG_ALL is set.  Before log_init() the
+	 * all_ranks flag is 0; rank-0 still emits. */
+	if (rank > 0 && !state.all_ranks)
 		return;
 
-	char buf[64];
-	FILE *fd = ev->data;
-	buf[strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S", ev->time)] = '\0';
-	fprintf(fd, "%s %-5s ", buf, log_level_string(ev->level));
-	vfprintf(fd, ev->fmt, ev->ap);
-	fprintf(fd, "\n");
-	fflush(fd);
+	struct timespec ts;
+	clock_gettime(CLOCK_REALTIME, &ts);
+	struct tm tm;
+	localtime_r(&ts.tv_sec, &tm);
+
+	char hdr[128];
+	int hlen;
+	if (state.all_ranks && rank > 0)
+		hlen = snprintf(hdr, sizeof hdr,
+			"[r=%d] %04d-%02d-%02d %02d:%02d:%02d.%03ld "
+			"%-5s [%s] ",
+			rank, 1900 + tm.tm_year, 1 + tm.tm_mon, tm.tm_mday,
+			tm.tm_hour, tm.tm_min, tm.tm_sec,
+			ts.tv_nsec / 1000000, LEVEL_NAMES[level], subsys);
+	else
+		hlen = snprintf(hdr, sizeof hdr,
+			"%04d-%02d-%02d %02d:%02d:%02d.%03ld "
+			"%-5s [%s] ",
+			1900 + tm.tm_year, 1 + tm.tm_mon, tm.tm_mday,
+			tm.tm_hour, tm.tm_min, tm.tm_sec,
+			ts.tv_nsec / 1000000, LEVEL_NAMES[level], subsys);
+	if (hlen < 0)
+		return;
+	if ((size_t)hlen >= sizeof hdr)
+		hlen = (int)sizeof hdr - 1;
+
+	char body[LINE_BUF_BYTES];
+	va_list ap;
+	va_start(ap, fmt);
+	int blen = vsnprintf(body, sizeof body, fmt, ap);
+	va_end(ap);
+	if (blen < 0)
+		return;
+	if ((size_t)blen >= sizeof body)
+		blen = (int)sizeof body - 1;
+
+	FILE *sink = (level >= LOG_WARN) ? stderr : stdout;
+	fwrite(hdr, 1, (size_t)hlen, sink);
+	fwrite(body, 1, (size_t)blen, sink);
+	fputc('\n', sink);
+	fflush(sink);
 }
 
 int log_init(void)
 {
-	enum log_level lvl;
-	const char *lvl_str = getenv(PHASE2_LOG_ENVVAR);
-	if (!lvl_str || log_level_from_lowercase(&lvl, lvl_str) < 0)
-		lvl = LOG_ERROR;
+	if (state.initialized)
+		return 0;
 
-	log_set_level(lvl);
-	log_add_callback(log_callback, stderr, lvl);
+	int lvl = LOG_INFO;
+	const char *env_lvl = getenv(PHASE2_LOG_ENVVAR);
+	if (env_lvl) {
+		int parsed;
+		if (parse_level(env_lvl, &parsed) == 0)
+			lvl = parsed;
+	}
+	log_threshold = lvl;
 
+	const char *env_all = getenv(PHASE2_LOG_ALL_ENVVAR);
+	state.all_ranks = (env_all && *env_all) ? 1 : 0;
+
+	setvbuf(stdout, NULL, _IOLBF, 0);
+	setvbuf(stderr, NULL, _IONBF, 0);
+
+	state.initialized = 1;
 	return 0;
+}
+
+void log_fini(void)
+{
+	fflush(stdout);
+	fflush(stderr);
+	state.initialized = 0;
 }

--- a/ph2run/ph2run.c
+++ b/ph2run/ph2run.c
@@ -12,6 +12,7 @@
 #include "circ/qdrift.h"
 #include "circ/trott.h"
 #include "circ/trott2.h"
+#define LOG_SUBSYS "ph2run"
 #include "log.h"
 #include "phase2.h"
 

--- a/ph2run/ph2run.c
+++ b/ph2run/ph2run.c
@@ -155,7 +155,7 @@ static int cmd_trott_write(data_id fid, void *data)
 
 	log_info("> Simulation summary (CSV):");
 	log_info("> n_qb,n_terms,n_dets,delta,n_steps,n_ranks,t_tot");
-	log_info("> %zu,%zu,%zu,%f,%zu,%d,%.3f", dt->tt.ct.hm.qb,
+	log_info("> %u,%zu,%zu,%f,%zu,%d,%.3f", dt->tt.ct.hm.qb,
 		dt->tt.ct.hm.len, dt->tt.ct.md.len, dt->tt_dt.delta,
 		dt->tt_dt.steps, wd.size, dt->t_tot);
 
@@ -166,6 +166,7 @@ static int cmd_trott_run(void *data)
 {
 	struct cmd_trott_dt *dt = data;
 
+	log_info("running simulation: %zu Trotter steps", dt->tt_dt.steps);
 	return trott_simul(&dt->tt);
 }
 
@@ -217,14 +218,20 @@ static int cmd_trott(void)
 {
 	int rt = -1;
 
-	if (data_exec(cmd_trott_init, &cmd_trott_dt) < 0)
-		goto ex;
-	if (timeit(cmd_trott_run, &cmd_trott_dt, &cmd_trott_dt.t_tot) < 0) {
-		log_error("Simulation error");
+	if (data_exec(cmd_trott_init, &cmd_trott_dt) < 0) {
+		log_error("trott: init failed");
 		goto ex;
 	}
-	if (data_exec(cmd_trott_write, &cmd_trott_dt) < 0)
+	if (timeit(cmd_trott_run, &cmd_trott_dt, &cmd_trott_dt.t_tot) < 0) {
+		log_error("trott: simulation failed after %.3f s",
+			cmd_trott_dt.t_tot);
 		goto ex;
+	}
+	log_info("simulation finished in %.3f s", cmd_trott_dt.t_tot);
+	if (data_exec(cmd_trott_write, &cmd_trott_dt) < 0) {
+		log_error("trott: writing results failed");
+		goto ex;
+	}
 
 	rt = 0; /* Success. */
 ex:
@@ -263,7 +270,7 @@ static int cmd_trott2_write(data_id fid, void *data)
 
 	log_info("> Simulation summary (CSV):");
 	log_info("> n_qb,n_terms,n_dets,delta,n_steps,n_ranks,t_tot");
-	log_info("> %zu,%zu,%zu,%f,%zu,%d,%.3f", dt->t2.ct.hm.qb,
+	log_info("> %u,%zu,%zu,%f,%zu,%d,%.3f", dt->t2.ct.hm.qb,
 		dt->t2.ct.hm.len, dt->t2.ct.md.len, dt->t2_dt.delta,
 		dt->t2_dt.steps, wd.size, dt->t_tot);
 
@@ -274,6 +281,8 @@ static int cmd_trott2_run(void *data)
 {
 	struct cmd_trott2_dt *dt = data;
 
+	log_info("running simulation: %zu symmetric Trotter steps",
+		dt->t2_dt.steps);
 	return trott2_simul(&dt->t2);
 }
 
@@ -324,14 +333,20 @@ static int cmd_trott2(void)
 {
 	int rt = -1;
 
-	if (data_exec(cmd_trott2_init, &cmd_trott2_dt) < 0)
-		goto ex;
-	if (timeit(cmd_trott2_run, &cmd_trott2_dt, &cmd_trott2_dt.t_tot) < 0) {
-		log_error("Simulation error");
+	if (data_exec(cmd_trott2_init, &cmd_trott2_dt) < 0) {
+		log_error("trott2: init failed");
 		goto ex;
 	}
-	if (data_exec(cmd_trott2_write, &cmd_trott2_dt) < 0)
+	if (timeit(cmd_trott2_run, &cmd_trott2_dt, &cmd_trott2_dt.t_tot) < 0) {
+		log_error("trott2: simulation failed after %.3f s",
+			cmd_trott2_dt.t_tot);
 		goto ex;
+	}
+	log_info("simulation finished in %.3f s", cmd_trott2_dt.t_tot);
+	if (data_exec(cmd_trott2_write, &cmd_trott2_dt) < 0) {
+		log_error("trott2: writing results failed");
+		goto ex;
+	}
 
 	rt = 0; /* Success. */
 ex:
@@ -384,6 +399,8 @@ static int cmd_qdrift_run(void *data)
 {
 	struct cmd_qdrift_dt *dt = data;
 
+	log_info("running simulation: %zu samples, depth %zu",
+		dt->qd_dt.samples, dt->qd_dt.depth);
 	return qdrift_simul(&dt->qd);
 }
 
@@ -444,14 +461,20 @@ int cmd_qdrift(void)
 {
 	int rt = -1;
 
-	if (data_exec(cmd_qdrift_init, &cmd_qdrift_dt) < 0)
-		goto ex;
-	if (timeit(cmd_qdrift_run, &cmd_qdrift_dt, &cmd_qdrift_dt.t_tot) < 0) {
-		log_error("Simulation error");
+	if (data_exec(cmd_qdrift_init, &cmd_qdrift_dt) < 0) {
+		log_error("qdrift: init failed");
 		goto ex;
 	}
-	if (data_exec(cmd_qdrift_write, &cmd_qdrift_dt) < 0)
+	if (timeit(cmd_qdrift_run, &cmd_qdrift_dt, &cmd_qdrift_dt.t_tot) < 0) {
+		log_error("qdrift: simulation failed after %.3f s",
+			cmd_qdrift_dt.t_tot);
 		goto ex;
+	}
+	log_info("simulation finished in %.3f s", cmd_qdrift_dt.t_tot);
+	if (data_exec(cmd_qdrift_write, &cmd_qdrift_dt) < 0) {
+		log_error("qdrift: writing results failed");
+		goto ex;
+	}
 
 	rt = 0; /* Success. */
 ex:
@@ -504,7 +527,7 @@ static int cmd_cmpsit_write(data_id fid, void *data)
 	log_info("> Simulation summary (CSV):");
 	log_info("> n_qb,n_terms,n_dets,samples,length,depth,angle_det"
 		 ",angle_rand,steps,n_ranks,t_tot");
-	log_info("> %zu,%zu,%zu,%zu,%zu,%zu,%.16f,%.16f,%zu,%d,%.3f",
+	log_info("> %u,%zu,%zu,%zu,%zu,%zu,%.16f,%.16f,%zu,%d,%.3f",
 		dt->cp.ct.hm.qb, dt->cp.ct.hm.len, dt->cp.ct.md.len,
 		dt->cp_dt.samples, dt->cp_dt.length, dt->cp_dt.depth,
 		dt->cp_dt.angle_det, dt->cp_dt.angle_rand, dt->cp_dt.steps,
@@ -517,6 +540,10 @@ static int cmd_cmpsit_run(void *data)
 {
 	struct cmd_cmpsit_dt *dt = data;
 
+	log_info("running simulation: %zu samples x %zu steps,"
+		 " L=%zu depth=%zu",
+		dt->cp_dt.samples, dt->cp_dt.steps, dt->cp_dt.length,
+		dt->cp_dt.depth);
 	return cmpsit_simul(&dt->cp);
 }
 
@@ -593,14 +620,20 @@ int cmd_cmpsit(void)
 {
 	int rt = -1;
 
-	if (data_exec(cmd_cmpsit_init, &cmd_cmpsit_dt) < 0)
-		goto ex;
-	if (timeit(cmd_cmpsit_run, &cmd_cmpsit_dt, &cmd_cmpsit_dt.t_tot) < 0) {
-		log_error("Simulation error");
+	if (data_exec(cmd_cmpsit_init, &cmd_cmpsit_dt) < 0) {
+		log_error("cmpsit: init failed");
 		goto ex;
 	}
-	if (data_exec(cmd_cmpsit_write, &cmd_cmpsit_dt) < 0)
+	if (timeit(cmd_cmpsit_run, &cmd_cmpsit_dt, &cmd_cmpsit_dt.t_tot) < 0) {
+		log_error("cmpsit: simulation failed after %.3f s",
+			cmd_cmpsit_dt.t_tot);
 		goto ex;
+	}
+	log_info("simulation finished in %.3f s", cmd_cmpsit_dt.t_tot);
+	if (data_exec(cmd_cmpsit_write, &cmd_cmpsit_dt) < 0) {
+		log_error("cmpsit: writing results failed");
+		goto ex;
+	}
 
 	rt = 0; /* Success. */
 ex:
@@ -640,8 +673,20 @@ int main(int argc, char **argv)
 		cmd_parse(cmpsit, CMD_CMPSIT);
 	}
 
-	if (world_init(nullptr, nullptr, WD_SEED) != WORLD_READY)
+	if (world_init(nullptr, nullptr, WD_SEED) != WORLD_READY) {
+		fprintf(stderr, "ph2run: world_init failed\n");
 		exit(-1);
+	}
+
+	if (cmd < 0) {
+		log_error("unrecognised subcommand: %s",
+			args.cmd ? args.cmd : "(none)");
+		world_free();
+		exit(-1);
+	}
+
+	log_info("subcommand: %s", args.cmd);
+	log_info("simul file: %s", args.simul);
 
 	switch (cmd) {
 	case CMD_TROTT:
@@ -656,8 +701,6 @@ int main(int argc, char **argv)
 	case CMD_CMPSIT:
 		rt = cmd_cmpsit();
 		break;
-	default:
-		fprintf(stderr, "Unrecognized command.\n");
 	}
 
 	world_free();

--- a/phase2/circ.c
+++ b/phase2/circ.c
@@ -1,10 +1,15 @@
+/* clock_gettime for circ_prog timing. */
+#define _POSIX_C_SOURCE 200809L
+
 #include "c23_compat.h"
 #include <complex.h>
 #include <math.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 
 #define LOG_SUBSYS "circ"
 #include "log.h"
@@ -143,11 +148,13 @@ static int circ_muldet_from_file(struct circ_muldet *m, const data_id fid)
 	return 0;
 }
 
-void circ_prog_init(struct circ_prog *prog, size_t len)
+void circ_prog_init(struct circ_prog *prog, size_t len, const char *unit)
 {
 	prog->i = 0;
 	prog->len = len;
 	prog->pc = 0;
+	prog->unit = unit ? unit : "step";
+	clock_gettime(CLOCK_MONOTONIC, &prog->t0);
 }
 
 void circ_prog_tick(struct circ_prog *prog)
@@ -157,8 +164,30 @@ void circ_prog_tick(struct circ_prog *prog)
 	const unsigned pc = prog->i * 100 / prog->len;
 	if (pc > prog->pc) {
 		prog->pc = pc;
-		log_info("Progress: %u%%", prog->pc);
+		log_debug("progress: %u%%", prog->pc);
 	}
+}
+
+void circ_prog_emit(const struct circ_prog *prog, const char *subsys)
+{
+	if (LOG_INFO < log_threshold)
+		return;
+
+	struct timespec now;
+	clock_gettime(CLOCK_MONOTONIC, &now);
+	const double elapsed = (now.tv_sec - prog->t0.tv_sec) +
+		(now.tv_nsec - prog->t0.tv_nsec) * 1e-9;
+	const double frac = (prog->len > 0)
+		? (double)prog->i / (double)prog->len
+		: 0.0;
+	const double eta = (frac > 0.0) ? elapsed * (1.0 / frac - 1.0) : 0.0;
+	const unsigned pc = (prog->len > 0)
+		? (unsigned)(prog->i * 100 / prog->len)
+		: 0;
+
+	log_emit(LOG_INFO, subsys ? subsys : LOG_SUBSYS, __FILE__, __LINE__,
+		"%s %zu/%zu (%u%%) elapsed %.2fs eta %.2fs", prog->unit,
+		prog->i, prog->len, pc, elapsed, eta);
 }
 
 int circ_values_init(struct circ_values *vals, size_t len)

--- a/phase2/circ.c
+++ b/phase2/circ.c
@@ -90,6 +90,7 @@ void circ_hamil_sort_lex(struct circ_hamil *hm)
 {
 	qsort(hm->terms, hm->len, sizeof(struct circ_hamil_term),
 		hamil_term_cmp_lex);
+	log_debug("hamil_sort_lex: sorted %zu terms", hm->len);
 }
 
 int circ_muldet_init(struct circ_muldet *md, size_t len)
@@ -182,29 +183,48 @@ int circ_init(struct circ *ct, const data_id fid, const size_t vals_len)
 	memset(&ct->md, 0, sizeof ct->md);
 	memset(&ct->cm, 0, sizeof ct->cm);
 
-	if (circ_hamil_from_file(&ct->hm, fid) < 0)
+	if (circ_hamil_from_file(&ct->hm, fid) < 0) {
+		log_error("circ_init: loading Hamiltonian failed");
 		goto err_hamil_init;
+	}
+	log_debug("circ_init: Hamiltonian loaded (%u qubits, %zu terms)",
+		ct->hm.qb, ct->hm.len);
 
-	if (data_state_prep_kind(fid, &ct->stprep_kind) < 0)
+	if (data_state_prep_kind(fid, &ct->stprep_kind) < 0) {
+		log_error("circ_init: state_prep kind probe failed");
 		goto err_stprep_kind;
+	}
 
 	switch (ct->stprep_kind) {
 	case STPREP_MULTIDET:
-		if (circ_muldet_from_file(&ct->md, fid) < 0)
+		if (circ_muldet_from_file(&ct->md, fid) < 0) {
+			log_error("circ_init: loading multidet state failed");
 			goto err_stprep_load;
+		}
+		log_debug("circ_init: multidet state (%zu dets)", ct->md.len);
 		break;
 	case STPREP_COEFF_MATRIX:
-		if (circ_coeff_init(&ct->cm, fid) < 0)
+		if (circ_coeff_init(&ct->cm, fid) < 0) {
+			log_error("circ_init: coeff_matrix init failed");
 			goto err_stprep_load;
+		}
+		log_debug("circ_init: coeff_matrix state (n_components=%zu)",
+			ct->cm.n_components);
 		break;
 	}
 
-	if (qreg_init(&ct->reg, ct->hm.qb) < 0)
+	if (qreg_init(&ct->reg, ct->hm.qb) < 0) {
+		log_error("circ_init: qreg_init failed");
 		goto err_qreg_init;
-	if (circ_cache_init(ct->reg.qb_hi, ct->reg.qb_lo) < 0)
+	}
+	if (circ_cache_init(ct->reg.qb_hi, ct->reg.qb_lo) < 0) {
+		log_error("circ_init: cache_init failed");
 		goto err_cache_init;
-	if (circ_values_init(&ct->vals, vals_len) < 0)
+	}
+	if (circ_values_init(&ct->vals, vals_len) < 0) {
+		log_error("circ_init: values_init failed (len=%zu)", vals_len);
 		goto err_vals_init;
+	}
 
 	return 0;
 

--- a/phase2/circ.c
+++ b/phase2/circ.c
@@ -157,7 +157,7 @@ void circ_prog_tick(struct circ_prog *prog)
 	const unsigned pc = prog->i * 100 / prog->len;
 	if (pc > prog->pc) {
 		prog->pc = pc;
-		log_info("Progress: %zu%%", prog->pc);
+		log_info("Progress: %u%%", prog->pc);
 	}
 }
 

--- a/phase2/circ.c
+++ b/phase2/circ.c
@@ -6,6 +6,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#define LOG_SUBSYS "circ"
 #include "log.h"
 #include "phase2/circ.h"
 #include "phase2/paulis.h"

--- a/phase2/circ_cache.c
+++ b/phase2/circ_cache.c
@@ -13,8 +13,12 @@
  * the cache (triggering the MPI exchange and rotations) and
  * then re-insert.  Overflow returns -1 to signal this.
  */
+#define LOG_SUBSYS "cache"
+
 #include "c23_compat.h"
 #include <stdlib.h>
+
+#include "log.h"
 
 #include "circ_cache.h"
 
@@ -58,8 +62,11 @@ int circ_cache_insert(struct paulis pa, double phi)
 
 void circ_cache_flush(circ_cache_op fn, void *data)
 {
-	if (ch_len > 0 && fn)
+	if (ch_len > 0 && fn) {
+		log_trace("flush: %zu terms (cache_max=%llu)", ch_len,
+			(unsigned long long)CACHE_MAX);
 		fn(pa_hi, pa_lo, phis, ch_len, data);
+	}
 
 	ch_len = 0;
 }

--- a/phase2/data.c
+++ b/phase2/data.c
@@ -1,3 +1,5 @@
+#define LOG_SUBSYS "data"
+
 #include "c23_compat.h"
 #include <errno.h>
 #include <stddef.h>
@@ -7,6 +9,7 @@
 
 #include "hdf5.h"
 
+#include "log.h"
 #include "phase2/data.h"
 #include "phase2/world.h"
 #include <complex.h>
@@ -15,20 +18,26 @@ static struct world_info WD;
 
 data_id data_open(const char *filename)
 {
-	if (world_info(&WD) != WORLD_READY)
+	if (world_info(&WD) != WORLD_READY) {
+		log_error("data_open(%s): world not ready", filename);
 		return DATA_INVALID_FID;
+	}
 	const hid_t acc_plist = H5Pcreate(H5P_FILE_ACCESS);
 	H5Pset_fapl_mpio(acc_plist, MPI_COMM_WORLD, MPI_INFO_NULL);
 
 	const hid_t fid = H5Fopen(filename, H5F_ACC_RDWR, acc_plist);
-	if (fid == H5I_INVALID_HID)
+	if (fid == H5I_INVALID_HID) {
+		log_error("data_open(%s): H5Fopen failed", filename);
 		return DATA_INVALID_FID;
+	}
 
+	log_debug("data_open(%s): fid=%lld", filename, (long long)fid);
 	return fid;
 }
 
 void data_close(const data_id fid)
 {
+	log_debug("data_close: fid=%lld", (long long)fid);
 	H5Fclose(fid);
 }
 
@@ -424,8 +433,10 @@ ex_open:
 int data_state_prep_kind(const data_id fid, enum stprep_kind *out)
 {
 	const hid_t sp_id = H5Gopen(fid, DATA_STPREP, H5P_DEFAULT);
-	if (sp_id == H5I_INVALID_HID)
+	if (sp_id == H5I_INVALID_HID) {
+		log_error("data_state_prep_kind: /state_prep group missing");
 		return -ENOENT;
+	}
 
 	const htri_t has_md =
 		H5Lexists(sp_id, DATA_STPREP_MULTIDET, H5P_DEFAULT);
@@ -433,25 +444,28 @@ int data_state_prep_kind(const data_id fid, enum stprep_kind *out)
 		H5Lexists(sp_id, DATA_STPREP_COEFFMAT, H5P_DEFAULT);
 	H5Gclose(sp_id);
 
-	if (has_md < 0 || has_cm < 0)
+	if (has_md < 0 || has_cm < 0) {
+		log_error("data_state_prep_kind: H5Lexists failed"
+			  " (has_md=%d has_cm=%d)",
+			(int)has_md, (int)has_cm);
 		return -EIO;
+	}
 	if (has_md && has_cm) {
-		fprintf(stderr,
-			"simul.h5: ambiguous state prep (both "
-			"/state_prep/multidet and "
-			"/state_prep/coeff_matrix present); "
-			"rebuild simul.h5 with exactly one\n");
+		log_error("simul.h5: ambiguous state prep (both"
+			  " /state_prep/multidet and /state_prep/coeff_matrix"
+			  " present); rebuild simul.h5 with exactly one");
 		return -EINVAL;
 	}
 	if (!has_md && !has_cm) {
-		fprintf(stderr,
-			"simul.h5: no state-prep subgroup found "
-			"(expected /state_prep/multidet or "
-			"/state_prep/coeff_matrix)\n");
+		log_error("simul.h5: no state-prep subgroup found"
+			  " (expected /state_prep/multidet or"
+			  " /state_prep/coeff_matrix)");
 		return -ENOENT;
 	}
 
 	*out = has_md ? STPREP_MULTIDET : STPREP_COEFF_MATRIX;
+	log_debug("data_state_prep_kind: %s",
+		(*out == STPREP_MULTIDET) ? "multidet" : "coeff_matrix");
 	return 0;
 }
 
@@ -682,10 +696,9 @@ int data_coeff_matrix_csf_count(const data_id fid, size_t *n)
 	 * silently empty state.
 	 */
 	if (ncomp == 0) {
-		fprintf(stderr,
-			"simul.h5: /state_prep/coeff_matrix/csf present "
-			"with n_components=0; remove the csf subgroup "
-			"or list at least one component\n");
+		log_error("simul.h5: /state_prep/coeff_matrix/csf present"
+			  " with n_components=0; remove the csf subgroup"
+			  " or list at least one component");
 		rt = -EINVAL;
 		goto ex;
 	}

--- a/phase2/qreg.c
+++ b/phase2/qreg.c
@@ -1,3 +1,5 @@
+#define LOG_SUBSYS "qreg"
+
 #include "c23_compat.h"
 #include <complex.h>
 #include <math.h>
@@ -6,6 +8,7 @@
 
 #include "mpi.h"
 
+#include "log.h"
 #include "phase2/paulis.h"
 #include "phase2/qreg.h"
 #include "phase2/world.h"
@@ -30,14 +33,19 @@ uint64_t qreg_getihi(const struct qreg *reg, uint64_t i)
 
 int qreg_init(struct qreg *reg, const uint32_t nqb)
 {
-	if (world_info(&reg->wd) != WORLD_READY)
+	if (world_info(&reg->wd) != WORLD_READY) {
+		log_error("qreg_init: world not ready");
 		return -1;
+	}
 
 	uint32_t nqb_hi = 0, nrk = reg->wd.size;
 	while (nrk >>= 1) /* nqb_hi = log2(nrk) */
 		nqb_hi++;
-	if (nqb_hi >= nqb)
+	if (nqb_hi >= nqb) {
+		log_error("qreg_init: nqb=%u must exceed log2(ranks)=%u",
+			nqb, nqb_hi);
 		return -1;
+	}
 	const uint32_t nqb_lo = nqb - nqb_hi;
 	const uint64_t namp = UINT64_C(1) << nqb_lo;
 
@@ -45,11 +53,17 @@ int qreg_init(struct qreg *reg, const uint32_t nqb)
 	const size_t nreqs = namp / msg_count;
 
 	MPI_Request *const reqs = malloc(sizeof *reqs * nreqs * 2);
-	if (!reqs)
+	if (!reqs) {
+		log_error("qreg_init: alloc reqs (%zu bytes)",
+			sizeof *reqs * nreqs * 2);
 		goto err_reqs_alloc;
+	}
 	_Complex double *const amp = malloc(sizeof *amp * namp * 2);
-	if (!amp)
+	if (!amp) {
+		log_error("qreg_init: alloc amp (%zu bytes)",
+			sizeof *amp * namp * 2);
 		goto err_amp_alloc;
+	}
 
 	reg->qb_lo = nqb_lo;
 	reg->qb_hi = nqb_hi;
@@ -61,9 +75,15 @@ int qreg_init(struct qreg *reg, const uint32_t nqb)
 	reg->reqs_rcv = reqs + nreqs;
 	reg->nreqs = nreqs;
 
-	if (qreg_backend_init(reg) < 0)
+	if (qreg_backend_init(reg) < 0) {
+		log_error("qreg_init: backend init failed");
 		goto err_backend_init;
+	}
 
+	log_debug("qreg_init: nqb=%u qb_lo=%u qb_hi=%u namp=%llu"
+		  " msg_count=%d nreqs=%zu",
+		nqb, nqb_lo, nqb_hi, (unsigned long long)namp, msg_count,
+		nreqs);
 	return 0;
 
 err_backend_init:

--- a/phase2/state_prep_coeff.c
+++ b/phase2/state_prep_coeff.c
@@ -4,6 +4,8 @@
  * public API contract; this file holds the implementation.
  */
 
+#define LOG_SUBSYS "prep"
+
 #include "c23_compat.h"
 #include <complex.h>
 #include <math.h>
@@ -16,6 +18,7 @@
 
 #include "combinations.h"
 #include "det_small.h"
+#include "log.h"
 #include "phase2/data.h"
 #include "phase2/qreg.h"
 #include "phase2/state_prep_coeff.h"
@@ -255,21 +258,34 @@ _Complex double state_prep_coeff_inner(struct qreg *reg,
 
 int state_prep_coeff_expand_all(struct qreg *reg, const struct circ_coeff *cm)
 {
+	log_debug("expand_all: n_sites=%u n_alpha=%u n_beta=%u"
+		  " closed_shell=%d tapered=%d n_components=%zu",
+		cm->n_sites, cm->n_alpha, cm->n_beta, cm->closed_shell,
+		cm->tapered, cm->n_components);
+
 	if (cm->n_components == 0) {
-		return state_prep_coeff_expand(reg, cm->n_sites, cm->n_alpha,
-			cm->n_beta, cm->C_alpha,
-			cm->closed_shell ? NULL : cm->C_beta, 1.0, cm->tapered,
-			0);
+		if (state_prep_coeff_expand(reg, cm->n_sites, cm->n_alpha,
+			    cm->n_beta, cm->C_alpha,
+			    cm->closed_shell ? NULL : cm->C_beta, 1.0,
+			    cm->tapered, 0) < 0) {
+			log_error("expand_all: single-block expand failed");
+			return -1;
+		}
+		return 0;
 	}
 
 	qreg_zero(reg);
 	for (size_t k = 0; k < cm->n_components; k++) {
 		const struct circ_coeff_block *b = &cm->blocks[k];
+		log_trace("expand_all: block %zu/%zu cf=%.6f", k + 1,
+			cm->n_components, b->cf);
 		if (state_prep_coeff_expand(reg, cm->n_sites, cm->n_alpha,
 			    cm->n_beta, b->C_alpha,
 			    cm->closed_shell ? NULL : b->C_beta, b->cf,
-			    cm->tapered, 1) < 0)
+			    cm->tapered, 1) < 0) {
+			log_error("expand_all: block %zu expand failed", k);
 			return -1;
+		}
 	}
 	return 0;
 }

--- a/phase2/world.c
+++ b/phase2/world.c
@@ -3,6 +3,7 @@
 
 #include "mpi.h"
 
+#define LOG_SUBSYS "world"
 #include "log.h"
 #include "xoshiro256ss.h"
 

--- a/test/t-circ.c
+++ b/test/t-circ.c
@@ -122,7 +122,7 @@ static void t_prog(void)
 {
 	struct circ_prog prog;
 
-	circ_prog_init(&prog, 100);
+	circ_prog_init(&prog, 100, "step");
 	TEST_EQ(prog.len, (size_t)100);
 	TEST_EQ(prog.i, (size_t)0);
 	TEST_EQ(prog.pc, 0u);

--- a/test/t-circ_cache.c
+++ b/test/t-circ_cache.c
@@ -1,3 +1,5 @@
+#define LOG_SUBSYS "test"
+
 #include "c23_compat.h"
 #include <complex.h>
 #include <math.h>

--- a/test/t-circ_trott.c
+++ b/test/t-circ_trott.c
@@ -1,3 +1,5 @@
+#define LOG_SUBSYS "test"
+
 #include "c23_compat.h"
 #include <complex.h>
 #include <math.h>

--- a/test/t-circ_trott2.c
+++ b/test/t-circ_trott2.c
@@ -1,3 +1,5 @@
+#define LOG_SUBSYS "test"
+
 #include "c23_compat.h"
 #include <complex.h>
 #include <math.h>

--- a/test/t-log.c
+++ b/test/t-log.c
@@ -1,0 +1,396 @@
+/*
+ * t-log -- unit tests for the phase2 logging subsystem.
+ *
+ * Built with -DDEBUG (the default for every test target),
+ * so log_trace and log_debug compile to real emits.  Tests
+ * capture stdout / stderr through a self-pipe, drain the
+ * pipe, and assert against the captured bytes.
+ *
+ * The complementary release-build coverage lives in
+ * test/t-log_release.c -- that binary is compiled with
+ * -UDEBUG and asserts the trace/debug strip.
+ */
+
+/* pipe(), dup2(), read(), close() need POSIX. */
+#define _POSIX_C_SOURCE 200809L
+
+#define LOG_SUBSYS "t-log"
+
+#include "c23_compat.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+
+#include "log.h"
+#include "phase2/world.h"
+
+#include "test.h"
+
+#define WD_SEED UINT64_C(0xa4f5c91d3e7b8062)
+#define CAP_BYTES (16 * 1024)
+
+struct capture {
+	int target_fd;
+	int saved_fd;
+	int pipe_r;
+	int pipe_w;
+};
+
+static int capture_start(struct capture *c, int target_fd)
+{
+	int pfd[2];
+	if (pipe(pfd) < 0)
+		return -1;
+	c->pipe_r = pfd[0];
+	c->pipe_w = pfd[1];
+	c->target_fd = target_fd;
+	c->saved_fd = dup(target_fd);
+	if (c->saved_fd < 0)
+		goto err;
+	if (dup2(c->pipe_w, target_fd) < 0)
+		goto err;
+	return 0;
+err:
+	close(c->pipe_r);
+	close(c->pipe_w);
+	return -1;
+}
+
+static int capture_end(struct capture *c, char *buf, size_t cap)
+{
+	if (c->target_fd == STDOUT_FILENO)
+		fflush(stdout);
+	else if (c->target_fd == STDERR_FILENO)
+		fflush(stderr);
+
+	if (dup2(c->saved_fd, c->target_fd) < 0)
+		return -1;
+	close(c->saved_fd);
+	close(c->pipe_w);
+	c->pipe_w = -1;
+
+	size_t total = 0;
+	while (total + 1 < cap) {
+		ssize_t n = read(c->pipe_r, buf + total, cap - 1 - total);
+		if (n <= 0)
+			break;
+		total += (size_t)n;
+	}
+	buf[total] = '\0';
+	close(c->pipe_r);
+	return (int)total;
+}
+
+static void env_reset(void)
+{
+	unsetenv(PHASE2_LOG_ENVVAR);
+	unsetenv(PHASE2_LOG_ALL_ENVVAR);
+	log_fini();
+}
+
+static int digits(const char *s, int n)
+{
+	for (int i = 0; i < n; i++)
+		if (s[i] < '0' || s[i] > '9')
+			return 0;
+	return 1;
+}
+
+/* -- tests ------------------------------------------------------------- */
+
+static void t_default_level(void)
+{
+	env_reset();
+	TEST_EQ(log_init(), 0);
+	TEST_EQ(log_threshold, LOG_INFO);
+}
+
+static void t_parse_levels(void)
+{
+	static const struct {
+		const char *env;
+		int level;
+	} cases[] = {
+		{ "trace", LOG_TRACE },
+		{ "Debug", LOG_DEBUG },
+		{ "INFO", LOG_INFO },
+		{ "w", LOG_WARN },
+		{ "error", LOG_ERROR },
+		{ "F", LOG_FATAL },
+	};
+	for (size_t i = 0; i < sizeof cases / sizeof cases[0]; i++) {
+		env_reset();
+		setenv(PHASE2_LOG_ENVVAR, cases[i].env, 1);
+		TEST_EQ(log_init(), 0);
+		TEST_EQ(log_threshold, cases[i].level);
+	}
+}
+
+static void t_parse_garbage(void)
+{
+	env_reset();
+	setenv(PHASE2_LOG_ENVVAR, "xyz", 1);
+	TEST_EQ(log_init(), 0);
+	/* Unparseable -> falls back to the default. */
+	TEST_EQ(log_threshold, LOG_INFO);
+}
+
+static void t_threshold_filters(void)
+{
+	env_reset();
+	setenv(PHASE2_LOG_ENVVAR, "warn", 1);
+	log_init();
+
+	char buf[CAP_BYTES];
+	struct capture cap;
+	TEST_EQ(capture_start(&cap, STDOUT_FILENO), 0);
+	log_info("hidden info");
+	capture_end(&cap, buf, sizeof buf);
+	TEST_ASSERT(strstr(buf, "hidden info") == NULL,
+		"info should be suppressed when threshold=warn");
+
+	TEST_EQ(capture_start(&cap, STDERR_FILENO), 0);
+	log_warn("visible warn");
+	capture_end(&cap, buf, sizeof buf);
+	TEST_ASSERT(strstr(buf, "visible warn") != NULL,
+		"warn must pass the warn threshold");
+}
+
+static void t_stream_split(void)
+{
+	env_reset();
+	setenv(PHASE2_LOG_ENVVAR, "trace", 1);
+	log_init();
+
+	char out[CAP_BYTES], err[CAP_BYTES];
+	struct capture co, ce;
+	TEST_EQ(capture_start(&co, STDOUT_FILENO), 0);
+	TEST_EQ(capture_start(&ce, STDERR_FILENO), 0);
+	log_trace("t-msg");
+	log_debug("d-msg");
+	log_info("i-msg");
+	log_warn("w-msg");
+	log_error("e-msg");
+	log_fatal("f-msg");
+	capture_end(&co, out, sizeof out);
+	capture_end(&ce, err, sizeof err);
+
+	TEST_ASSERT(strstr(out, "t-msg") != NULL, "trace on stdout");
+	TEST_ASSERT(strstr(out, "d-msg") != NULL, "debug on stdout");
+	TEST_ASSERT(strstr(out, "i-msg") != NULL, "info on stdout");
+	TEST_ASSERT(strstr(out, "w-msg") == NULL, "warn NOT on stdout");
+	TEST_ASSERT(strstr(out, "e-msg") == NULL, "error NOT on stdout");
+	TEST_ASSERT(strstr(out, "f-msg") == NULL, "fatal NOT on stdout");
+
+	TEST_ASSERT(strstr(err, "w-msg") != NULL, "warn on stderr");
+	TEST_ASSERT(strstr(err, "e-msg") != NULL, "error on stderr");
+	TEST_ASSERT(strstr(err, "f-msg") != NULL, "fatal on stderr");
+	TEST_ASSERT(strstr(err, "i-msg") == NULL, "info NOT on stderr");
+	TEST_ASSERT(strstr(err, "d-msg") == NULL, "debug NOT on stderr");
+}
+
+static void t_format_shape(void)
+{
+	env_reset();
+	setenv(PHASE2_LOG_ENVVAR, "info", 1);
+	log_init();
+
+	char buf[CAP_BYTES];
+	struct capture cap;
+	TEST_EQ(capture_start(&cap, STDOUT_FILENO), 0);
+	log_info("payload-XYZ");
+	capture_end(&cap, buf, sizeof buf);
+
+	/* Expect: YYYY-MM-DD HH:MM:SS.mmm INFO  [t-log] payload-XYZ\n */
+	TEST_ASSERT(digits(buf + 0, 4), "year digits");
+	TEST_ASSERT(buf[4] == '-', "dash after year");
+	TEST_ASSERT(digits(buf + 5, 2), "month digits");
+	TEST_ASSERT(buf[7] == '-', "dash after month");
+	TEST_ASSERT(digits(buf + 8, 2), "day digits");
+	TEST_ASSERT(buf[10] == ' ', "space after date");
+	TEST_ASSERT(digits(buf + 11, 2), "hour digits");
+	TEST_ASSERT(buf[13] == ':', "colon");
+	TEST_ASSERT(digits(buf + 14, 2), "minute digits");
+	TEST_ASSERT(buf[16] == ':', "colon");
+	TEST_ASSERT(digits(buf + 17, 2), "second digits");
+	TEST_ASSERT(buf[19] == '.', "dot before ms");
+	TEST_ASSERT(digits(buf + 20, 3), "millisecond digits");
+	TEST_ASSERT(buf[23] == ' ', "space after ms");
+	TEST_ASSERT(strstr(buf, " INFO  ") != NULL, "INFO level pad");
+	TEST_ASSERT(strstr(buf, "[t-log]") != NULL, "subsystem tag");
+	TEST_ASSERT(strstr(buf, "payload-XYZ\n") != NULL, "message + newline");
+}
+
+static void t_subsystem_explicit(void)
+{
+	env_reset();
+	setenv(PHASE2_LOG_ENVVAR, "info", 1);
+	log_init();
+
+	char buf[CAP_BYTES];
+	struct capture cap;
+	TEST_EQ(capture_start(&cap, STDOUT_FILENO), 0);
+	/* Bypass the macro to install a custom subsystem. */
+	log_emit(LOG_INFO, "myunit", __FILE__, __LINE__, "hello %s", "world");
+	capture_end(&cap, buf, sizeof buf);
+
+	TEST_ASSERT(strstr(buf, "[myunit]") != NULL,
+		"explicit subsystem appears verbatim");
+	TEST_ASSERT(strstr(buf, "hello world") != NULL, "printf passthrough");
+}
+
+static void t_subsystem_missing(void)
+{
+	env_reset();
+	setenv(PHASE2_LOG_ENVVAR, "info", 1);
+	log_init();
+
+	char buf[CAP_BYTES];
+	struct capture cap;
+	TEST_EQ(capture_start(&cap, STDOUT_FILENO), 0);
+	/* LOG_SUBSYS is defined as "?" by the header when no
+	 * file-level override is given.  Simulate by passing
+	 * "?" directly. */
+	log_emit(LOG_INFO, "?", __FILE__, __LINE__, "anon");
+	capture_end(&cap, buf, sizeof buf);
+	TEST_ASSERT(strstr(buf, "[?]") != NULL, "missing LOG_SUBSYS -> [?]");
+}
+
+static void t_printf_passthrough(void)
+{
+	env_reset();
+	setenv(PHASE2_LOG_ENVVAR, "info", 1);
+	log_init();
+
+	char buf[CAP_BYTES];
+	struct capture cap;
+	TEST_EQ(capture_start(&cap, STDOUT_FILENO), 0);
+	log_info("d=%d s=%s z=%zu g=%g p=%%", -42, "abc",
+		(size_t)1234567890u, 3.14);
+	capture_end(&cap, buf, sizeof buf);
+	TEST_ASSERT(strstr(buf, "d=-42 s=abc z=1234567890 g=3.14 p=%") != NULL,
+		"printf format spec round-trip");
+}
+
+static void t_long_message(void)
+{
+	env_reset();
+	setenv(PHASE2_LOG_ENVVAR, "info", 1);
+	log_init();
+
+	char big[8192];
+	memset(big, 'x', sizeof big - 1);
+	big[sizeof big - 1] = '\0';
+
+	char buf[CAP_BYTES];
+	struct capture cap;
+	TEST_EQ(capture_start(&cap, STDOUT_FILENO), 0);
+	log_info("%s", big);
+	int n = capture_end(&cap, buf, sizeof buf);
+	TEST_ASSERT(n > 0, "long message produced output");
+	TEST_ASSERT(buf[n - 1] == '\n', "output ends with newline despite trunc");
+}
+
+static void t_rank_prefix_off(void)
+{
+	env_reset();
+	setenv(PHASE2_LOG_ENVVAR, "info", 1);
+	log_init();
+
+	char buf[CAP_BYTES];
+	struct capture cap;
+	TEST_EQ(capture_start(&cap, STDOUT_FILENO), 0);
+	log_info("no-prefix");
+	capture_end(&cap, buf, sizeof buf);
+	/* Rank 0, ALL off: no [r=...] prefix; line starts
+	 * with a digit (the year). */
+	TEST_ASSERT(buf[0] >= '0' && buf[0] <= '9',
+		"rank-0 line starts with year, no rank prefix");
+}
+
+static void t_init_idempotent(void)
+{
+	env_reset();
+	setenv(PHASE2_LOG_ENVVAR, "info", 1);
+	TEST_EQ(log_init(), 0);
+	/* Calling again is a no-op; threshold unchanged. */
+	const int before = log_threshold;
+	setenv(PHASE2_LOG_ENVVAR, "warn", 1);
+	TEST_EQ(log_init(), 0);
+	TEST_EQ(log_threshold, before);
+
+	/* After fini, init reloads env. */
+	log_fini();
+	TEST_EQ(log_init(), 0);
+	TEST_EQ(log_threshold, LOG_WARN);
+}
+
+static void t_filtered_perf(void)
+{
+	env_reset();
+	setenv(PHASE2_LOG_ENVVAR, "warn", 1);
+	log_init();
+
+	struct timespec t0, t1;
+	clock_gettime(CLOCK_MONOTONIC, &t0);
+	for (int i = 0; i < 1000000; i++)
+		log_trace("filtered: %d", i);
+	clock_gettime(CLOCK_MONOTONIC, &t1);
+
+	const double dt = (t1.tv_sec - t0.tv_sec) +
+		(t1.tv_nsec - t0.tv_nsec) * 1e-9;
+	TEST_ASSERT(dt < 0.25,
+		"1e6 filtered log_trace calls in %.3f s (budget <0.25 s)",
+		dt);
+}
+
+static void t_trace_debug_emit_in_debug_build(void)
+{
+	env_reset();
+	setenv(PHASE2_LOG_ENVVAR, "trace", 1);
+	log_init();
+
+	char buf[CAP_BYTES];
+	struct capture cap;
+	TEST_EQ(capture_start(&cap, STDOUT_FILENO), 0);
+	log_trace("trace-emit");
+	log_debug("debug-emit");
+	capture_end(&cap, buf, sizeof buf);
+
+#ifdef DEBUG
+	TEST_ASSERT(strstr(buf, "trace-emit") != NULL,
+		"DEBUG build emits trace");
+	TEST_ASSERT(strstr(buf, "debug-emit") != NULL,
+		"DEBUG build emits debug");
+#else
+	TEST_ASSERT(strstr(buf, "trace-emit") == NULL,
+		"non-DEBUG build strips trace");
+	TEST_ASSERT(strstr(buf, "debug-emit") == NULL,
+		"non-DEBUG build strips debug");
+#endif
+}
+
+int main(void)
+{
+	world_init(nullptr, nullptr, WD_SEED);
+
+	t_default_level();
+	t_parse_levels();
+	t_parse_garbage();
+	t_threshold_filters();
+	t_stream_split();
+	t_format_shape();
+	t_subsystem_explicit();
+	t_subsystem_missing();
+	t_printf_passthrough();
+	t_long_message();
+	t_rank_prefix_off();
+	t_init_idempotent();
+	t_filtered_perf();
+	t_trace_debug_emit_in_debug_build();
+
+	world_free();
+	return 0;
+}

--- a/test/t-log_release.c
+++ b/test/t-log_release.c
@@ -1,0 +1,130 @@
+/*
+ * t-log_release -- verifies that log_trace and log_debug
+ * vanish from a build that does NOT define DEBUG.
+ *
+ * The Makefile builds this single test target with
+ * -UDEBUG cancelling the project-wide -DDEBUG that
+ * applies to every other test.  Inside this translation
+ * unit, log_trace and log_debug must expand to ((void)0)
+ * and therefore produce no bytes on either sink even with
+ * log_threshold = LOG_TRACE.
+ */
+
+#define _POSIX_C_SOURCE 200809L
+
+#define LOG_SUBSYS "t-log_release"
+
+#include "c23_compat.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "log.h"
+#include "phase2/world.h"
+
+#include "test.h"
+
+#define WD_SEED UINT64_C(0xa4f5c91d3e7b8062)
+#define CAP_BYTES (4096)
+
+struct capture {
+	int target_fd;
+	int saved_fd;
+	int pipe_r;
+	int pipe_w;
+};
+
+static int capture_start(struct capture *c, int target_fd)
+{
+	int pfd[2];
+	if (pipe(pfd) < 0)
+		return -1;
+	c->pipe_r = pfd[0];
+	c->pipe_w = pfd[1];
+	c->target_fd = target_fd;
+	c->saved_fd = dup(target_fd);
+	if (c->saved_fd < 0 || dup2(c->pipe_w, target_fd) < 0) {
+		close(c->pipe_r);
+		close(c->pipe_w);
+		return -1;
+	}
+	return 0;
+}
+
+static int capture_end(struct capture *c, char *buf, size_t cap)
+{
+	if (c->target_fd == STDOUT_FILENO)
+		fflush(stdout);
+	else if (c->target_fd == STDERR_FILENO)
+		fflush(stderr);
+	dup2(c->saved_fd, c->target_fd);
+	close(c->saved_fd);
+	close(c->pipe_w);
+
+	size_t total = 0;
+	while (total + 1 < cap) {
+		ssize_t n = read(c->pipe_r, buf + total, cap - 1 - total);
+		if (n <= 0)
+			break;
+		total += (size_t)n;
+	}
+	buf[total] = '\0';
+	close(c->pipe_r);
+	return (int)total;
+}
+
+static void t_trace_debug_stripped(void)
+{
+#ifdef DEBUG
+	TEST_FAIL("t-log_release MUST be built with -UDEBUG");
+#endif
+
+	unsetenv(PHASE2_LOG_ENVVAR);
+	unsetenv(PHASE2_LOG_ALL_ENVVAR);
+	log_fini();
+	log_init();
+	log_threshold = LOG_TRACE; /* lowest gate -- everything in */
+
+	char out[CAP_BYTES], err[CAP_BYTES];
+	struct capture co, ce;
+	capture_start(&co, STDOUT_FILENO);
+	capture_start(&ce, STDERR_FILENO);
+	log_trace("MUST-NOT-APPEAR-trace");
+	log_debug("MUST-NOT-APPEAR-debug");
+	capture_end(&co, out, sizeof out);
+	capture_end(&ce, err, sizeof err);
+
+	TEST_ASSERT(out[0] == '\0',
+		"log_trace/log_debug must produce zero bytes on stdout"
+		" in release builds (got: %s)", out);
+	TEST_ASSERT(err[0] == '\0',
+		"log_trace/log_debug must produce zero bytes on stderr"
+		" in release builds (got: %s)", err);
+}
+
+static void t_info_still_works(void)
+{
+	unsetenv(PHASE2_LOG_ENVVAR);
+	log_fini();
+	log_init();
+
+	char buf[CAP_BYTES];
+	struct capture cap;
+	capture_start(&cap, STDOUT_FILENO);
+	log_info("info-survives-release");
+	capture_end(&cap, buf, sizeof buf);
+	TEST_ASSERT(strstr(buf, "info-survives-release") != NULL,
+		"log_info must still emit in release builds");
+}
+
+int main(void)
+{
+	world_init(nullptr, nullptr, WD_SEED);
+
+	t_trace_debug_stripped();
+	t_info_still_works();
+
+	world_free();
+	return 0;
+}

--- a/test/t-qreg.c
+++ b/test/t-qreg.c
@@ -1,3 +1,5 @@
+#define LOG_SUBSYS "test"
+
 #include "c23_compat.h"
 #include <complex.h>
 #include <math.h>

--- a/test/t-world.c
+++ b/test/t-world.c
@@ -1,3 +1,5 @@
+#define LOG_SUBSYS "test"
+
 #include "c23_compat.h"
 #include <stdint.h>
 


### PR DESCRIPTION
## Summary

Branch `logging` reshapes the logging subsystem end-to-end:

- **Core rewrite** (`lib/log.c`, `include/log.h`).  Drop
  the 32-slot callback table; one stdout sink for
  trace/debug/info, one stderr sink for warn/error/fatal.
  Millisecond timestamps via `clock_gettime` +
  `localtime_r`.  Subsystem tag captured per file via
  `#define LOG_SUBSYS "<name>"` before
  `#include "log.h"`.  Default level `LOG_INFO`.
  `PHASE2_LOG_ALL=1` opens up rank > 0 logging with
  `[r=N]` prefix.  Line-buffered stdout +
  `fflush` per emit so SLURM `tail -f` shows lines as
  they happen.

- **DEBUG-gated trace/debug.**  Release builds strip
  `log_trace` and `log_debug` to `((void)0)` — zero
  cost, no format string in `.rodata`.  `make debug`
  keeps them.

- **Extensive coverage.**  ~30 new debug/trace sites
  across `phase2/` and `circ/` (qreg init/batches,
  data open/close, state_prep_kind decision, hamil sort,
  state_prep_coeff Ma/Mb, per-step boundaries in
  trott/trott2/qdrift, per-sample in cmpsit).  ~15 new
  info sites in `ph2run` (resolved options, file path,
  "running simulation: N steps", "simulation finished in
  X.Y s", per-phase error reporting).

- **Rich progress lines.**  `circ_prog_emit()` formats
  `step 17/100 (17%) elapsed 4.31s eta 21.0s` at info,
  emitted by trott/trott2/qdrift/cmpsit after every step
  or sample.  No throttling — volume management is the
  operator's choice.

- **Tests.**  `test/t-log` (with `-DDEBUG`) covers
  filter, format, stream split, ms timestamp, subsystem
  tag, MPI prefix, idempotency, perf sanity (10⁶
  filtered traces under 250 ms).  `test/t-log_release`
  (built with `-UDEBUG`) verifies the strip end-to-end:
  zero bytes from `log_trace`/`log_debug` even with
  `log_threshold = LOG_TRACE`.

- **Policy and reference.**  New `doc/logging.md`
  (mandatory levels table, format, env vars, MPI, build
  gating, performance budget, **policy for new code**,
  examples).  `doc/phase2.md §6.3` shrinks to a pointer.
  `README.md` "Run" section updated.

- **Pre-existing format warnings fixed** along the way
  (`%zu` for `uint32_t hm.qb` in CSV summaries; `%u`
  for `uint64_t n` in bench).

## Commit layout

```
8cb5897 doc: add doc/logging.md; refresh README and phase2.md
ba0776c circ: emit rich progress lines from algorithm layer
75a5a8e ph2run: rich info coverage and per-phase error reporting
de32f56 phase2: add debug/trace coverage and error emission
3fa64b7 log: tag every emitter with LOG_SUBSYS
5b4b8e2 test: exercise the logging subsystem
b9e0938 log: rewrite for ms timestamp, subsystem tag, stream split
```

Each commit self-contained; `make check` passes between.

## Default behaviour, end to end

```
$ ./ph2run/ph2run -S test/data/H2O_CAS56.h5 trott -D 0.1 -s 5
2026-05-13 22:45:38.814 INFO  [world]  *** Init ***
2026-05-13 22:45:38.814 INFO  [world]  World size: 1
2026-05-13 22:45:38.814 INFO  [world]  Backend: qreg
2026-05-13 22:45:38.814 INFO  [ph2run] subcommand: trott
2026-05-13 22:45:38.814 INFO  [ph2run] simul file: test/data/H2O_CAS56.h5
2026-05-13 22:45:38.814 INFO  [ph2run] *** Circuit: trott ***
2026-05-13 22:45:38.814 INFO  [ph2run] running simulation: 5 Trotter steps
2026-05-13 22:45:38.818 INFO  [trott]  step 1/5 (20%) elapsed 0.00s eta 0.01s
2026-05-13 22:45:38.821 INFO  [trott]  step 2/5 (40%) elapsed 0.01s eta 0.01s
...
2026-05-13 22:45:38.830 INFO  [ph2run] simulation finished in 0.015 s
```

## Test plan

- [x] `make check` (every test passes; baseline)
- [x] `./ph2run/ph2run --version` → 1.1.0 (unchanged)
- [x] `make check check/t-log check/t-log_release` (the new tests)
- [x] Release build of `ph2run/ph2run` carries no
  `log_trace`/`log_debug` format strings (`strings`
  + `nm` verified)
- [x] Debug build (`make distclean && make debug`)
  emits all six levels through `PHASE2_LOG=trace`
- [ ] `make check-mpi MPIRANKS=4` (verify on CI)
- [ ] CUDA backend smoke (verify on GPU runner)

🤖 Generated with [Claude Code](https://claude.com/claude-code)