### PR TITLE
test: parallel cargo-style runner; macros, drift guard, docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,6 +98,12 @@ test/t-*
 !test/t-*.h
 !test/t-*.py
 
+# Parallel runner binary and its fixture binaries; the
+# fixture .c sources stay tracked.
+test/run
+test/run-fixtures/*
+!test/run-fixtures/*.c
+
 *.egg-info/
 __pycache__/
 

--- a/Makefile
+++ b/Makefile
@@ -317,7 +317,28 @@ $(TESTDIR)/t-circ_trott2: $(CIRCDIR)/trott2.o
 $(TESTDIR)/t-circ_trott_coeff: $(CIRCDIR)/trott.o
 $(TESTDIR)/t-circ_trott2_coeff: $(CIRCDIR)/trott2.o
 
-build-test: $(TESTS)
+build-test: check-tests-coverage $(TESTS)
+
+# Guard against a t-*.c file being added to test/ but
+# forgotten in TESTS / TESTS_SLOW above -- a silent
+# omission would otherwise produce a partial suite that
+# CI cannot tell from a full one.
+.PHONY: check-tests-coverage
+check-tests-coverage:
+	@tmp=$$(mktemp -d);					\
+	ls $(TESTDIR)/t-*.c 2>/dev/null				\
+		| sed 's|\.c$$||' | sort > $$tmp/expected;	\
+	for t in $(TESTS) $(TESTS_SLOW); do echo $$t; done	\
+		| sort > $$tmp/declared;			\
+	missing=$$(comm -23 $$tmp/expected $$tmp/declared);	\
+	rc=0;							\
+	if [ -n "$$missing" ]; then				\
+		echo "test/: t-*.c files not in TESTS:";	\
+		echo "$$missing";				\
+		rc=1;						\
+	fi;							\
+	rm -rf $$tmp;						\
+	exit $$rc
 
 CHECKS	:= $(TESTS:$(TESTDIR)/%=check/%)
 

--- a/Makefile
+++ b/Makefile
@@ -317,7 +317,13 @@ $(TESTDIR)/t-circ_trott2: $(CIRCDIR)/trott2.o
 $(TESTDIR)/t-circ_trott_coeff: $(CIRCDIR)/trott.o
 $(TESTDIR)/t-circ_trott2_coeff: $(CIRCDIR)/trott2.o
 
-build-test: check-tests-coverage $(TESTS)
+build-test: check-tests-coverage $(TESTS) $(TESTDIR)/run
+
+# Parallel cargo-style runner.  Standalone C binary, no
+# phase2 / MPI / HDF5 dependencies.  Build with the test
+# CFLAGS so any DEBUG / sanitiser flags apply consistently.
+$(TESTDIR)/run: $(TESTDIR)/run.c
+	$(CC) -std=c11 -Wall -Wextra -O2 -o $@ $<
 
 # Guard against a t-*.c file being added to test/ but
 # forgotten in TESTS / TESTS_SLOW above -- a silent
@@ -451,6 +457,7 @@ clean:
 distclean: clean
 	@$(RM) $(BENCHES)
 	@$(RM) $(TESTS)
+	@$(RM) $(TESTDIR)/run
 	@$(RM) $(PROGS)
 	@$(RM) libphase2.so
 

--- a/Makefile
+++ b/Makefile
@@ -368,45 +368,34 @@ check-tests-coverage:
 	rm -rf $$tmp;						\
 	exit $$rc
 
-CHECKS	:= $(TESTS:$(TESTDIR)/%=check/%)
-
-.PHONY: $(CHECKS)
-# Tests are always built with -DDEBUG so log_trace / log_debug
-# in include/log.h expand to real emits.  t-log_release
-# below cancels this so the release-build strip of
-# trace/debug macros can be verified end-to-end -- the
-# override must come after the blanket -DDEBUG so the
-# trailing -UDEBUG wins on the gcc command line.
+# Tests are always built with -DDEBUG so log_trace /
+# log_debug in include/log.h expand to real emits.
+# t-log_release cancels this so the release-build strip
+# of trace/debug macros can be verified end-to-end --
+# the override must come after the blanket -DDEBUG so
+# the trailing -UDEBUG wins on the gcc command line.
 $(TESTS): CFLAGS += -DDEBUG -g -Og
-$(CHECKS): CFLAGS += -DDEBUG -g -Og
 $(TESTDIR)/t-log_release: CFLAGS += -UDEBUG
-check/t-log_release: CFLAGS += -UDEBUG
-$(CHECKS): check/%: $(TESTDIR)/%
-	@./$< && echo "$< OK" || (echo "$<: FAIL"; exit 1)
 
+# All check targets delegate to test/run; the runner
+# fans the suite out across cores, captures per-test
+# stdout/stderr, and prints a cargo-style summary.
+# See test/run.c for the harness contract.
 .PHONY: check
-check: $(CHECKS) check-python
+check: build-test
+	@./$(TESTDIR)/run -- $(TESTS)				\
+		$(TESTDIR)/t-ref-coeff_matrix.py
 
-# Python harness cross-validates the C expansion path against
-# an independent in-tree reference oracle.  Depends on
-# build-test (for the t-state_prep_coeff_expand binary).
-.PHONY: check-python
-check-python: build-test
-	@python3 $(TESTDIR)/t-ref-coeff_matrix.py	\
-		&& echo "$(TESTDIR)/t-ref-coeff_matrix.py OK"	\
-		|| (echo "$(TESTDIR)/t-ref-coeff_matrix.py: FAIL"; exit 1)
-
-# Slow tests: built but not part of the default check target.
+# Slow tests: built but not part of the default check
+# target.
 .PHONY: build-test-slow
 build-test-slow: $(TESTS_SLOW)
 
-CHECKS_SLOW	:= $(TESTS_SLOW:$(TESTDIR)/%=check/%)
-.PHONY: $(CHECKS_SLOW)
-$(CHECKS_SLOW): CFLAGS += -DDEBUG -g -Og
-$(CHECKS_SLOW): check/%: $(TESTDIR)/%
-	@./$< && echo "$< OK" || (echo "$<: FAIL"; exit 1)
 .PHONY: check-slow
-check-slow: $(CHECKS_SLOW)
+check-slow: build-test-slow $(TESTDIR)/run
+	@./$(TESTDIR)/run -- $(TESTS_SLOW)
+
+.PHONY: test-slow
 test-slow: check-slow
 
 # Sanitizer / valgrind targets.  These rebuild from scratch
@@ -449,19 +438,23 @@ test-mpi-asan:
 			( echo "$$tt: FAIL"; exit 1 );			\
 	done
 
-#check: build-test
-#	@for tt in $(TESTS); do						\
-#		./$$tt &&						\
-#			echo "$$tt: OK" ||				\
-#			( echo "$$tt: FAIL"; exit 1 );			\
-#	done
-
+.PHONY: check-mpi
 check-mpi: build-test
-	@for tt in $(TESTS); do						\
-		$(MPIRUN) -n $(MPIRANKS) $(MPIFLAGS) ./$$tt && 		\
-			echo "$$tt: OK" ||				\
-			( echo "$$tt: FAIL"; exit 1 );			\
-	done
+	@./$(TESTDIR)/run --mpiranks=$(MPIRANKS) -- $(TESTS)
+
+# Pattern target: `make check-<filter>` runs the
+# subset of the suite whose effective names match
+# `<filter>*` (fnmatch glob).  The effective name is
+# the basename without the `t-` prefix and the `.py`
+# suffix.  Examples:
+#   make check-data    -> all t-data_*
+#   make check-paulis  -> just t-paulis
+#   make check-circ    -> all t-circ*
+# Explicit targets (check-mpi, check-slow,
+# check-tests-coverage) win over this pattern.
+check-%: build-test
+	@./$(TESTDIR)/run --filter='$**' -- $(TESTS)		\
+		$(TESTDIR)/t-ref-coeff_matrix.py
 
 
 # --------------------------------------------------------------------------- #

--- a/Makefile
+++ b/Makefile
@@ -273,6 +273,7 @@ bench-mpi: build-bench
 # Testing                                                                     #
 # --------------------------------------------------------------------------- #
 TESTDIR		:= ./test
+RUNFIXDIR	:= $(TESTDIR)/run-fixtures
 CFLAGS		+= -I$(TESTDIR) -I$(PHASE2DIR) -DPH2_TESTDIR=\"$(TESTDIR)\"
 
 TESTS		:= $(TESTDIR)/t-bitstring_index			\
@@ -301,9 +302,30 @@ TESTS		:= $(TESTDIR)/t-bitstring_index			\
 			$(TESTDIR)/t-prob				\
 			$(TESTDIR)/t-qreg				\
 			$(TESTDIR)/t-ref-bendazzoli			\
+			$(TESTDIR)/t-run				\
 			$(TESTDIR)/t-state_prep_coeff_csf		\
 			$(TESTDIR)/t-state_prep_coeff_expand		\
 			$(TESTDIR)/t-world
+
+# Synthetic fixtures used by t-run to drive the runner
+# against controlled pass / fail / signal / banner
+# outcomes.  Each fixture is a tiny self-contained C
+# program with no phase2 / MPI / HDF5 deps.
+RUNFIX		:= $(RUNFIXDIR)/pass					\
+			$(RUNFIXDIR)/fail				\
+			$(RUNFIXDIR)/sleep				\
+			$(RUNFIXDIR)/abort				\
+			$(RUNFIXDIR)/banner
+
+$(RUNFIXDIR)/%: $(RUNFIXDIR)/%.c
+	$(CC) -std=c11 -Wall -Wextra -O2 -o $@ $<
+
+# t-run is a meta-test: it shells out to ./test/run, so
+# both the runner and its fixtures must exist before
+# t-run is invoked.  Use order-only prereqs (after `|`)
+# so the implicit %: %.c link line does not try to feed
+# the runner / fixture binaries to ld.
+$(TESTDIR)/t-run: | $(TESTDIR)/run $(RUNFIX)
 
 TESTS_SLOW	:= $(TESTDIR)/t-state_prep_coeff_large
 
@@ -458,6 +480,7 @@ distclean: clean
 	@$(RM) $(BENCHES)
 	@$(RM) $(TESTS)
 	@$(RM) $(TESTDIR)/run
+	@$(RM) $(RUNFIX)
 	@$(RM) $(PROGS)
 	@$(RM) libphase2.so
 

--- a/README.md
+++ b/README.md
@@ -135,15 +135,17 @@ Tests and benchmarks
 --------------------
 
 ```bash
-make check                 # full C test suite
-make check-mpi MPIRANKS=4  # same, under MPI
-make check-python          # cross-check coeff_matrix expansion
+make check                 # full test suite (parallel, cargo-style)
+make check-mpi MPIRANKS=4  # same, each test under mpirun -n 4
+make check-data            # subset filter (e.g. check-paulis, check-circ)
 make bench                 # paulis and qreg micro-benchmarks
 make test-asan             # ASan + UBSan build
 make test-valgrind         # leak/UB check via valgrind
 ```
 
-Test fixtures live in `test/data/`.
+Test fixtures live in `test/data/`.  See
+[doc/testing.md](doc/testing.md) for the harness
+contract, runner flags, and recipes for adding tests.
 
 
 Documentation
@@ -153,6 +155,8 @@ Documentation
   design, kernels (CPU and CUDA), algorithms, API, build.
 - [doc/logging.md](doc/logging.md) — logging subsystem:
   format, levels, env vars, MPI, policy for new code.
+- [doc/testing.md](doc/testing.md) — test subsystem:
+  harness, parallel runner, conventions, recipes.
 - [doc/python.md](doc/python.md) — Python interface.
 - [doc/simul-h5-specs.md](doc/simul-h5-specs.md) — HDF5
   input/output schema.

--- a/doc/phase2.md
+++ b/doc/phase2.md
@@ -1534,20 +1534,23 @@ happens during data loading in `circ_hamil_load`.
 
 ### 10.1 Make Targets
 
-| Target        | Description                           |
-|---------------|---------------------------------------|
-| `all`         | Build everything (programs, benchmarks, tests) |
-| `build`       | Build `ph2run` and dependencies       |
-| `build-test`  | Build the test suite                  |
-| `build-bench` | Build benchmarks                      |
-| `check`       | Run all tests (single rank)           |
-| `check-mpi`   | Run all tests under MPI               |
-| `bench`       | Run benchmarks (single rank)          |
-| `bench-mpi`   | Run benchmarks under MPI              |
-| `debug`       | Build with debug flags (-g -Og)       |
-| `clean`       | Remove object files                   |
-| `distclean`   | Remove object files, binaries, tests  |
-| `format`      | Run clang-format on all sources       |
+| Target                 | Description                           |
+|------------------------|---------------------------------------|
+| `all`                  | Build everything (programs, benchmarks, tests) |
+| `build`                | Build `ph2run` and dependencies       |
+| `build-test`           | Build the test suite + runner         |
+| `build-bench`          | Build benchmarks                      |
+| `check`                | Run the full test suite (parallel, cargo-style) |
+| `check-mpi`            | Run the suite under `mpirun -n MPIRANKS` |
+| `check-slow`           | Run TESTS_SLOW (excluded from default `check`) |
+| `check-<filter>`       | Run the subset matching `<filter>*` (`check-data`) |
+| `check-tests-coverage` | Guard: every `test/t-*.c` is in TESTS / TESTS_SLOW |
+| `bench`                | Run benchmarks (single rank)          |
+| `bench-mpi`            | Run benchmarks under MPI              |
+| `debug`                | Build with debug flags (-g -Og)       |
+| `clean`                | Remove object files                   |
+| `distclean`            | Remove object files, binaries, tests  |
+| `format`               | Run clang-format on all sources       |
 
 ### 10.2 Backend Selection
 
@@ -1591,15 +1594,17 @@ convention `t-<area>[_<aspect>]`:
 | `t-circ_prepst_coeff`           | Slater-Condon state-prep dispatch |
 | `t-state_prep_coeff_*`          | expand, CSF superposition, large reference |
 | `t-ref-bendazzoli`              | precomputed CSF amplitudes reference |
+| `t-run`                         | self-tests for the parallel runner   |
 
 The Python harness `test/t-ref-coeff_matrix.py` cross-checks
 the C expansion against an in-tree reference oracle in
-`test/ref/coeff_matrix_reference.py`; it is run by
-`make check-python`.
+`test/ref/coeff_matrix_reference.py`; the unified `check`
+target runs it alongside the C tests.
 
-Test data files reside in `test/data/`.  The slow test
-`t-state_prep_coeff_large` is built and run separately via
-`make build-test-slow` / `make check-slow`.  Sanitiser and
-valgrind variants are available as `make test-asan`,
-`make test-valgrind`, `make test-mpi-asan`.  Tests are
-built with `-DDEBUG -g -Og` flags.
+`make check` and friends delegate to the cargo-style
+parallel runner at `test/run` -- per-test stdout/stderr
+capture, TTY-aware colour, fnmatch filtering, MPI wrap.
+See [doc/testing.md](testing.md) for the full subsystem
+reference: macro contract, fixture pattern, runner flags,
+recipes for adding tests, sanitiser / valgrind targets.
+Test data files reside in `test/data/`.

--- a/doc/testing.md
+++ b/doc/testing.md
@@ -1,0 +1,346 @@
+# phase2 testing
+
+Single-page reference for the test subsystem.  Sources:
+`test/`.  Harness header: `test/test.h`.  Runner:
+`test/run.c`.  Make integration: the `Testing`
+section of `Makefile`.
+
+## 1. Quick reference
+
+Build and run the full suite:
+
+```
+make check
+```
+
+Subset:
+
+```
+make check-data            # all t-data_* tests
+make check-paulis          # just t-paulis
+make check-circ            # all t-circ*
+```
+
+Under MPI:
+
+```
+make check-mpi MPIRANKS=4  # wrap each test in mpirun -n 4
+```
+
+Slow tests (built separately, not part of default
+`check`):
+
+```
+make check-slow
+```
+
+Sanitiser / valgrind variants:
+
+```
+make test-asan
+make test-valgrind
+make test-mpi-asan
+```
+
+
+## 2. Layout
+
+```
+test/
+  test.h               -- macro core (TEST_FAIL, TEST_ASSERT, ...)
+  t-<subsys>[_<aspect>].c   -- one binary per logical unit
+  t-data.h             -- per-subsystem fixture helpers (model)
+  t-ref-coeff_matrix.py     -- Python cross-validator
+  run.c                -- the parallel runner (built to test/run)
+  t-run.c              -- self-tests for the runner
+  run-fixtures/        -- synthetic fixtures driven by t-run
+  data/                -- on-disk HDF5 fixtures for the C tests
+  ref/                 -- in-tree Python reference oracles
+```
+
+C binaries follow the prefix convention
+`t-<subsys>[_<aspect>].c`.  Examples:
+`t-paulis.c`, `t-data_hamil.c`, `t-circ_trott_coeff.c`.
+The matching binary lands under the same name and is
+listed in the Makefile's `TESTS` variable.
+
+The slow test (`t-state_prep_coeff_large`) is declared
+in `TESTS_SLOW` and is excluded from default `check`.
+
+The Makefile target `check-tests-coverage` enforces
+that every `test/t-*.c` source appears in TESTS or
+TESTS_SLOW; it is wired as a prerequisite of
+`build-test`, so a forgotten declaration fails the
+build immediately.
+
+
+## 3. `test.h` macros
+
+```c
+#include "test.h"
+
+TEST_FAIL("unreachable branch hit (n=%zu)", n);
+TEST_ASSERT(p != NULL, "alloc returned NULL for %zu bytes", sz);
+TEST_EQ(rc, 0);
+TEST_NEAR(observed, expected, 1e-12);
+TEST_CNEAR(amp, 1.0 + 0.5*I, 1e-15);
+```
+
+| Macro                       | Use                                |
+| --------------------------- | ---------------------------------- |
+| `TEST_FAIL(fmt, ...)`       | unconditional abort                |
+| `TEST_ASSERT(expr, fmt, ...)` | abort iff `expr` is false        |
+| `TEST_EQ(a, b)`             | shorthand for `a == b`             |
+| `TEST_NEAR(a, b, eps)`      | `fabs(a - b) <= eps` (double)      |
+| `TEST_CNEAR(a, b, eps)`     | `cabs(a - b) <= eps` (_Complex)    |
+
+All five are statements (`do { ... } while (0)`) -- do
+not use in expression position.  Failure emits one
+line to stderr in the GCC-error format:
+
+```
+<file>:<line>: FAIL [<func>]: <msg>
+```
+
+so editors recognise the prefix and jump directly to
+the failing source location.  After the line, the
+process exits with non-zero status.  No global cleanup
+runs; the OS reaps the world.
+
+
+## 4. Per-subsystem fixture headers
+
+`test.h` itself stays macro-only.  Shared fixture
+arrays, helper functions, and the
+`test_fixture_copy`-style scaffolding go in a
+per-subsystem header.  `test/t-data.h` is the
+canonical model:
+
+```c
+/* test/t-data.h */
+static const struct test_data {
+        const char *path;
+        size_t      n_orb, n_alpha, n_beta;
+        ...
+} TEST_DATA[] = { ... };
+
+static void test_fixture_copy(const char *src, char *dst);
+```
+
+A test then `#include "t-data.h"` and iterates
+`TEST_DATA[]`.  This keeps the macro core small and
+keeps fixture wiring out of `test.h`.
+
+The Makefile already lists `t-data.h` as a per-test
+prerequisite, so a touch to the header rebuilds every
+binary that consumes it.
+
+Every test calls `world_init(NULL, NULL, SEED)` at
+the top of `main` and `world_free()` before return.
+Any `TEST_*` macro aborts via `exit`, leaving the
+world uninitialised on the way out -- that is
+intentional; the kernel reaps it.
+
+
+## 5. The runner
+
+`test/run` is a standalone single-file C program
+(libc + POSIX only, no phase2 / MPI / HDF5 deps).
+It takes a list of test paths and runs them in
+parallel, capturing per-test output, and prints a
+cargo-style summary.
+
+```
+./test/run [OPTIONS] -- TEST...
+```
+
+| Flag             | Default      | Effect                              |
+| ---------------- | ------------ | ----------------------------------- |
+| `--jobs=N`       | `nproc`      | parallel job count                  |
+| `--mpiranks=N`   | 0 (off)      | wrap each test in `mpirun -n N`     |
+| `--filter=GLOB`  | none         | fnmatch(3) against effective name   |
+| `--verbose`, `-v`| off          | stream per-test stdout; forces `--jobs=1` |
+| `--no-color`     | TTY-detected | force plain output                  |
+| `--help`, `-h`   |              | usage + exit                        |
+
+The *effective name* is the basename of the test path
+with the leading `t-` and any `.py` suffix stripped:
+`./test/t-data_mpi -> "data_mpi"`,
+`./test/t-ref-coeff_matrix.py -> "ref-coeff_matrix"`.
+Filter examples: `--filter='data*'`,
+`--filter='*coeff*'`, `--filter='paulis'`.
+
+### 5.1 Output
+
+```
+running 31 tests
+
+test t-bitstring_index ............ ok (0.038s)
+test t-circ_cache ................. ok (0.041s)
+test t-data_mpi ................... FAILED (1.234s)
+...
+
+failures:
+
+---- t-data_mpi stdout ----
+<captured>
+---- t-data_mpi stderr ----
+test/t-data_mpi.c:108: FAIL [t_bcast_eq]: rank 1 diverges
+(exit 1)
+
+failures:
+    t-data_mpi
+
+test result: FAILED. 30 passed; 1 failed; finished in 6.32s
+```
+
+Per-test elapsed reported at millisecond precision so
+sub-second variation between parallel tests is
+visible.  Colour is on iff stdout is a TTY or
+`FORCE_COLOR=1` is set; `--no-color` and pipe
+redirection turn it off.  The plain format is
+byte-identical apart from the ANSI escapes.
+
+### 5.2 Exit codes
+
+| Code | Meaning                                       |
+| ---- | --------------------------------------------- |
+| 0    | every dispatched test passed (or empty suite) |
+| 1    | one or more tests failed                      |
+| 2    | usage error (no `--` / no test paths)         |
+
+Children killed by a signal are reported as
+`128 + signum` in the failure dump; the runner itself
+still exits 1.
+
+### 5.3 Process model
+
+Each test runs as a `fork(2)` + `execvp(3)` child.
+stdout and stderr are captured to per-test tempfiles
+under a `mkdtemp(3)` directory in `/tmp`; the captures
+are surfaced under labelled headers in the failure
+dump.  The parent uses `waitpid(-1, ...)` to reap
+completions in arrival order and dispatches a new
+child into each freed slot.  Children inherit the
+parent's process group, so a `SIGINT` at the terminal
+takes the whole run down cleanly without a custom
+handler.
+
+### 5.4 HDF5 file locking
+
+HDF5 1.10+ takes an advisory `flock(2)` on every open;
+parallel readers of committed fixtures intermittently
+lose the race.  The runner sets
+`HDF5_USE_FILE_LOCKING=FALSE` at startup, propagated
+to every child via the environment.  All in-tree
+tests open fixtures read-only, so suppressing the
+lock is safe.
+
+The architectural detail (process model, fd plumbing,
+mkstemp choreography, Python wrapping, MPI wrapping)
+is documented at the top of `test/run.c`.
+
+
+## 6. Make integration
+
+| Target                  | Effect                                  |
+| ----------------------- | --------------------------------------- |
+| `build-test`            | build all test binaries + `test/run`    |
+| `build-test-slow`       | also build TESTS_SLOW                   |
+| `check`                 | runner on TESTS + the .py harness       |
+| `check-mpi`             | runner with `--mpiranks=$(MPIRANKS)`    |
+| `check-slow`            | runner on TESTS_SLOW                    |
+| `check-<filter>`        | runner with `--filter='<filter>*'`      |
+| `check-tests-coverage`  | guard: every `t-*.c` is declared        |
+| `test-asan`             | rebuild + run under ASan/UBSan          |
+| `test-valgrind`         | rebuild + run under valgrind            |
+| `test-mpi-asan`         | rebuild + run a small MPI subset under ASan |
+
+The runner is invoked once per `make check`-family
+target; it does its own parallel dispatch.  Make's
+`-j` is therefore orthogonal -- not load-amplifying,
+because the runner already saturates the cores.
+
+`check-<filter>` is a pattern target; the stem is
+threaded straight into the runner's `--filter` as
+`<stem>*`.  Examples:
+
+```
+make check-data    -> --filter='data*'
+make check-paulis  -> --filter='paulis*'
+make check-circ    -> --filter='circ*'
+```
+
+Explicit targets (`check-mpi`, `check-slow`,
+`check-tests-coverage`) win over this pattern.
+
+
+## 7. Adding a new test
+
+1. Create `test/t-<subsys>[_<aspect>].c` using the
+   `test.h` macros.  If the test needs shared
+   fixtures, include the per-subsystem fixture
+   header (`test/t-data.h` or analogue).
+2. Add the binary to `TESTS` in `Makefile`.  If it
+   is a long-running test, add it to `TESTS_SLOW`
+   instead.
+3. `make check`.  The `check-tests-coverage`
+   prerequisite of `build-test` will fail the build
+   if step 2 was forgotten.
+
+The Makefile already arranges:
+
+- `-DDEBUG -g -Og` for every test binary,
+- `-UDEBUG` for `t-log_release` (verifies the
+  release-build strip of trace/debug macros),
+- a generic dependency on `test/test.h`, `test/t-data.h`,
+  the phase2/lib/ph2run object sets.
+
+
+## 8. Adding a runner self-test
+
+The runner has its own meta-test at `test/t-run.c`
+which exercises `./test/run` via `popen(3)` against
+synthetic fixtures under `test/run-fixtures/`
+(pass, fail, sleep, abort, banner).  To add a new
+scenario:
+
+1. Drop a tiny C program under `test/run-fixtures/`
+   that produces the controlled outcome you want
+   (specific exit code, output pattern, runtime).
+2. Add it to the `RUNFIX` Makefile variable so it
+   gets built.
+3. Add a scenario function in `test/t-run.c` that
+   shells out to `./test/run` and asserts via
+   `must_contain` / `must_not_contain` / `TEST_EQ`.
+   Call it from `main`.
+
+Self-tests are skipped automatically when the
+runner is invoked under `mpirun` -- the meta-test
+is single-process by design.
+
+
+## 9. Sanitiser and valgrind targets
+
+`test-asan` rebuilds the suite with
+`-fsanitize=address,undefined -fno-omit-frame-pointer
+-g` on both `EXTRA_CFLAGS` and `EXTRA_LDFLAGS`, then
+runs `make check`.  OpenMPI's startup path triggers
+internal "leaks" via libevent / libopen-pal that we
+cannot fix from here; the rule disables leak
+detection (`detect_leaks=0`) but keeps every other
+ASan + UBSan diagnostic active.
+
+`test-valgrind` runs the existing test binaries
+under `valgrind --leak-check=full --track-origins=yes`
+in a serial loop.  Does *not* go through the runner
+(valgrind already serialises and produces its own
+captures).
+
+`test-mpi-asan` is a narrow build: rebuild with
+ASan flags, then run a single representative MPI
+test (`t-circ_trott_coeff`) under
+`mpirun -n 4 -x ASAN_OPTIONS=...`.
+
+All three targets are independent of the cargo-style
+runner and reuse `$(TESTS)` directly.

--- a/test/run-fixtures/abort.c
+++ b/test/run-fixtures/abort.c
@@ -1,0 +1,11 @@
+/*
+ * Synthetic test fixture: raises SIGABRT.  The runner
+ * reports a signal-killed child as `128 + signum`,
+ * i.e. exit code 134 here (SIGABRT == 6).
+ */
+#include <stdlib.h>
+
+int main(void)
+{
+	abort();
+}

--- a/test/run-fixtures/banner.c
+++ b/test/run-fixtures/banner.c
@@ -1,0 +1,15 @@
+/*
+ * Synthetic test fixture: writes a distinctive banner
+ * to both stdout and stderr, then exits 1.  Exercises
+ * the runner's failure-dump output (captured streams
+ * surfaced under `---- t-banner stdout ----` /
+ * `---- t-banner stderr ----` headers).
+ */
+#include <stdio.h>
+
+int main(void)
+{
+	fputs("BANNER_STDOUT_LINE\n", stdout);
+	fputs("BANNER_STDERR_LINE\n", stderr);
+	return 1;
+}

--- a/test/run-fixtures/fail.c
+++ b/test/run-fixtures/fail.c
@@ -1,0 +1,5 @@
+/* Synthetic test fixture: exits 1. */
+int main(void)
+{
+	return 1;
+}

--- a/test/run-fixtures/pass.c
+++ b/test/run-fixtures/pass.c
@@ -1,0 +1,5 @@
+/* Synthetic test fixture: exits 0. */
+int main(void)
+{
+	return 0;
+}

--- a/test/run-fixtures/sleep.c
+++ b/test/run-fixtures/sleep.c
@@ -1,0 +1,16 @@
+/*
+ * Synthetic test fixture: sleeps 250 ms, then exits 0.
+ * Four copies run in parallel exercise the runner's
+ * --jobs concurrency: serial would take ~1.0 s wall,
+ * parallel ~0.25 s.
+ */
+#define _POSIX_C_SOURCE 200809L
+
+#include <time.h>
+
+int main(void)
+{
+	const struct timespec ts = { 0, 250000000 };
+	nanosleep(&ts, NULL);
+	return 0;
+}

--- a/test/run.c
+++ b/test/run.c
@@ -1,0 +1,743 @@
+/*
+ * test/run -- parallel test harness for phase2.
+ *
+ * The runner takes a list of test paths on the command
+ * line, spawns up to N children at once (N defaults to
+ * the number of online cores), captures each test's
+ * stdout and stderr to per-test tempfiles, and reports
+ * results in a cargo-test-style stream:
+ *
+ *     running 31 tests
+ *     test t-bitstring_index ............ ok (0.04s)
+ *     test t-data_mpi ................... FAILED (1.23s)
+ *     ...
+ *
+ *     failures:
+ *     ---- t-data_mpi stdout ----
+ *     <captured>
+ *     ---- t-data_mpi stderr ----
+ *     <captured>
+ *
+ *     by subsystem:
+ *       data     9 passed  (1/9 failed)
+ *       ...
+ *
+ *     test result: FAILED. 30 passed; 1 failed; \
+ *         finished in 6.32s
+ *
+ * Architectural notes
+ * -------------------
+ *
+ *  - Tests are *not* discovered here.  The caller (the
+ *    Makefile, or a developer invoking the binary
+ *    directly) passes the list of test paths after `--`.
+ *    The runner stays decoupled from the TESTS /
+ *    TESTS_SLOW manifest.
+ *
+ *  - Each child is a plain fork+execvp.  stdout and
+ *    stderr are redirected to mkstemp(3) tempfiles in a
+ *    per-run mkdtemp(3) directory under /tmp.  Parent
+ *    waits with waitpid(-1, &status, 0) so completions
+ *    are processed in arrival order, then dispatches
+ *    the next pending test into the freed slot.
+ *
+ *  - Python tests (suffix `.py`) are recognised and
+ *    executed via `python3 <path>` instead of running
+ *    the path as a native binary.  Under MPI mode
+ *    (--mpiranks=N) Python tests are skipped: they are
+ *    rank-0 cross-validators and don't make sense under
+ *    mpirun.
+ *
+ *  - Subsystem is the prefix between `t-` and the next
+ *    `_` (or the rest of the name if no underscore):
+ *    t-data_mpi.c -> "data"; t-paulis.c -> "paulis".
+ *    Used for the by-subsystem rollup at the end.
+ *
+ *  - Colour is on iff stdout is a TTY (or FORCE_COLOR is
+ *    set).  --no-color forces plain output.  The plain
+ *    format is byte-identical apart from the ANSI
+ *    escapes, so logs are diffable.
+ *
+ *  - SIGINT propagates naturally: the children share
+ *    the parent's process group, so Ctrl-C at the
+ *    terminal kills all live children and the parent
+ *    sees them as terminated.  No custom handler.
+ *
+ * No phase2 / MPI / HDF5 dependencies; libc + POSIX
+ * only.  Build line:
+ *
+ *     cc -std=c11 -Wall -Wextra -O3 test/run.c -o test/run
+ */
+
+#define _POSIX_C_SOURCE 200809L
+
+#include <errno.h>
+#include <fcntl.h>
+#include <fnmatch.h>
+#include <getopt.h>
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <time.h>
+#include <unistd.h>
+
+
+/* -- diagnostics ----------------------------------------------------- */
+
+/*
+ * Print a fatal error to stderr (with errno text if
+ * non-zero) and exit non-zero.  Used for unrecoverable
+ * setup failures (mkstemp, fork, ...).  Test failures
+ * proper go through the regular pass/fail path; this is
+ * for the harness itself dying.
+ */
+__attribute__((noreturn, format(printf, 1, 2)))
+static void die(const char *fmt, ...)
+{
+	va_list ap;
+	va_start(ap, fmt);
+	fputs("test/run: ", stderr);
+	vfprintf(stderr, fmt, ap);
+	va_end(ap);
+	if (errno)
+		fprintf(stderr, ": %s", strerror(errno));
+	fputc('\n', stderr);
+	exit(2);
+}
+
+
+/* -- options --------------------------------------------------------- */
+
+struct opts {
+	int jobs;		/* parallel slots; 1..N */
+	int mpiranks;		/* 0 = no MPI wrap */
+	const char *filter;	/* fnmatch glob; NULL = no filter */
+	bool verbose;		/* don't capture stdout; forces jobs=1 */
+	bool color;		/* emit ANSI escapes? */
+};
+
+/*
+ * sysconf-derived default for --jobs.  Falls back to 1
+ * if the platform refuses to answer (some sandboxes).
+ */
+static int default_jobs(void)
+{
+	const long n = sysconf(_SC_NPROCESSORS_ONLN);
+	return (n > 0) ? (int)n : 1;
+}
+
+/*
+ * Colour-on-TTY policy: the user's --no-color flag wins
+ * absolutely.  Otherwise honour FORCE_COLOR (set in CI
+ * configs that wrap colour-aware tools), and finally
+ * fall back to isatty(stdout).
+ */
+static bool default_color(void)
+{
+	if (getenv("FORCE_COLOR"))
+		return true;
+	return isatty(STDOUT_FILENO) != 0;
+}
+
+static void usage(FILE *out)
+{
+	fputs(
+		"usage: test/run [OPTIONS] -- TEST...\n"
+		"\n"
+		"  --jobs=N         parallel job count "
+		"(default: number of cores)\n"
+		"  --mpiranks=N     wrap each test with "
+		"`mpirun -n N` (skips .py tests)\n"
+		"  --filter=GLOB    fnmatch against the "
+		"effective test name (no\n"
+		"                   `t-` prefix, no `.py` "
+		"suffix)\n"
+		"  --verbose, -v    pass each test's stdout "
+		"through; forces --jobs=1\n"
+		"  --no-color       force plain output "
+		"(default: detect TTY)\n"
+		"  --help, -h       this help\n"
+		"\n"
+		"  TEST...          list of test paths (native "
+		"binaries and/or .py)\n",
+		out);
+}
+
+static void parse_opts(int argc, char **argv, struct opts *o, int *first_pos)
+{
+	*o = (struct opts){
+		.jobs = default_jobs(),
+		.mpiranks = 0,
+		.filter = NULL,
+		.verbose = false,
+		.color = default_color(),
+	};
+
+	static const struct option long_opts[] = {
+		{ "jobs",     required_argument, NULL, 'j' },
+		{ "mpiranks", required_argument, NULL, 'm' },
+		{ "filter",   required_argument, NULL, 'f' },
+		{ "verbose",  no_argument,       NULL, 'v' },
+		{ "no-color", no_argument,       NULL, 'C' },
+		{ "help",     no_argument,       NULL, 'h' },
+		{ 0 },
+	};
+	int c;
+	while ((c = getopt_long(argc, argv, "vh", long_opts, NULL)) != -1) {
+		switch (c) {
+		case 'j': o->jobs = atoi(optarg); break;
+		case 'm': o->mpiranks = atoi(optarg); break;
+		case 'f': o->filter = optarg; break;
+		case 'v': o->verbose = true; break;
+		case 'C': o->color = false; break;
+		case 'h': usage(stdout); exit(0);
+		default:  usage(stderr); exit(2);
+		}
+	}
+	if (o->verbose)
+		o->jobs = 1;	/* keep per-test output legible */
+	if (o->jobs < 1)
+		o->jobs = 1;
+	*first_pos = optind;
+}
+
+
+/* -- test_result ----------------------------------------------------- */
+
+/*
+ * Per-test state carried through the run.  Populated at
+ * setup time (path/name/subsys) and filled in as the
+ * test runs (pid -> exit_code, elapsed, captured-output
+ * paths).
+ */
+struct test_result {
+	const char *path;	/* exactly as supplied on argv */
+	char *name;		/* basename(path) minus t- prefix
+				 * and .py suffix; owned */
+	char *subsys;		/* prefix of name up to first `_`;
+				 * owned (substring of name) */
+	bool is_python;		/* path ends in `.py` */
+	bool dispatched;	/* spawned? */
+	bool reaped;		/* completed and recorded? */
+	bool passed;		/* exit_code == 0 */
+	pid_t pid;
+	int exit_code;		/* WEXITSTATUS, or 128+sig on signal */
+	double elapsed;		/* wall-clock seconds */
+	struct timespec t0;	/* spawn time */
+	char *out_path;		/* captured stdout (owned) */
+	char *err_path;		/* captured stderr (owned) */
+	int out_fd, err_fd;	/* open fds during spawn; closed in parent */
+};
+
+/*
+ * Compute a malloc'd "effective name" -- basename minus
+ * the conventional `t-` prefix and the `.py` suffix if
+ * present.  Examples:
+ *
+ *     test/t-data_mpi             -> "data_mpi"
+ *     ./test/t-ref-coeff_matrix.py -> "ref-coeff_matrix"
+ *
+ * Caller owns the result.
+ */
+static char *make_name(const char *path)
+{
+	const char *slash = strrchr(path, '/');
+	const char *base = slash ? slash + 1 : path;
+	if (strncmp(base, "t-", 2) == 0)
+		base += 2;
+	const size_t len = strlen(base);
+	const size_t cut = (len >= 3 && strcmp(base + len - 3, ".py") == 0)
+		? len - 3 : len;
+	char *out = malloc(cut + 1);
+	if (!out)
+		die("malloc");
+	memcpy(out, base, cut);
+	out[cut] = '\0';
+	return out;
+}
+
+/*
+ * Subsystem = the prefix of the effective name up to
+ * the first `_`.  Falls back to the whole name when
+ * there's no underscore (e.g. "paulis", "world").  The
+ * returned pointer is a substring of `name`; lifetime
+ * follows it.
+ */
+static char *make_subsys(char *name)
+{
+	const char *under = strchr(name, '_');
+	if (!under)
+		return name;
+	const size_t cut = (size_t)(under - name);
+	char *out = malloc(cut + 1);
+	if (!out)
+		die("malloc");
+	memcpy(out, name, cut);
+	out[cut] = '\0';
+	return out;
+}
+
+
+/* -- filtering ------------------------------------------------------- */
+
+/*
+ * Drop tests whose effective name doesn't match `glob`
+ * (fnmatch with default flags -- POSIX glob syntax,
+ * `*` does not cross `/` but our names are flat).
+ *
+ * `*n_tests` shrinks in place; freed entries are *not*
+ * reclaimed (the run is short-lived).
+ */
+static void filter_tests(struct test_result *tests, size_t *n_tests,
+	const char *glob)
+{
+	if (!glob)
+		return;
+	size_t w = 0;
+	for (size_t r = 0; r < *n_tests; r++) {
+		if (fnmatch(glob, tests[r].name, 0) == 0)
+			tests[w++] = tests[r];
+	}
+	*n_tests = w;
+}
+
+
+/* -- child spawn ----------------------------------------------------- */
+
+/*
+ * Prepare per-test stdout/stderr tempfiles, fork, and
+ * execvp into the test (or python3, or mpirun).  Records
+ * the pid + spawn time on `r`; bubbles fatal errno up
+ * via die().
+ *
+ * The tempfile fds are opened in the parent before fork
+ * so both processes see the same inode.  The child
+ * dup2's them onto fds 1 and 2, then closes the
+ * originals.  The parent closes its copies immediately
+ * after fork -- the file remains open via the child's
+ * stdio handles, and we'll reopen it for reading once
+ * the child exits.
+ */
+static void spawn_one(struct test_result *r, const struct opts *o,
+	const char *tmpdir)
+{
+	/* Tempfile names: <tmpdir>/<name>.out and .err.
+	 * The name is already filename-safe (alnum + `_` +
+	 * `-`); no escaping needed. */
+	const size_t pathsz = strlen(tmpdir) + strlen(r->name) + 8;
+	r->out_path = malloc(pathsz);
+	r->err_path = malloc(pathsz);
+	if (!r->out_path || !r->err_path)
+		die("malloc");
+	snprintf(r->out_path, pathsz, "%s/%s.out", tmpdir, r->name);
+	snprintf(r->err_path, pathsz, "%s/%s.err", tmpdir, r->name);
+	r->out_fd = open(r->out_path,
+		O_CREAT | O_TRUNC | O_RDWR, 0600);
+	r->err_fd = open(r->err_path,
+		O_CREAT | O_TRUNC | O_RDWR, 0600);
+	if (r->out_fd < 0 || r->err_fd < 0)
+		die("open(%s/%s)", tmpdir, r->name);
+
+	clock_gettime(CLOCK_MONOTONIC, &r->t0);
+
+	const pid_t pid = fork();
+	if (pid < 0)
+		die("fork");
+
+	if (pid == 0) {
+		/* child */
+		if (o->verbose) {
+			/* Stream through to the parent's TTY for
+			 * live observation.  No capture. */
+			close(r->out_fd);
+			close(r->err_fd);
+		} else {
+			if (dup2(r->out_fd, STDOUT_FILENO) < 0
+				|| dup2(r->err_fd, STDERR_FILENO) < 0)
+				_exit(126);
+			close(r->out_fd);
+			close(r->err_fd);
+		}
+
+		/* argv assembly: at most six slots (mpirun -n
+		 * NN python3 path NULL).  Static buffer is
+		 * fine -- it lives until exec consumes it. */
+		const char *argv[8] = { 0 };
+		char ranks_buf[16];
+		int ai = 0;
+		if (o->mpiranks > 0 && !r->is_python) {
+			snprintf(ranks_buf, sizeof ranks_buf, "%d",
+				o->mpiranks);
+			argv[ai++] = "mpirun";
+			argv[ai++] = "-n";
+			argv[ai++] = ranks_buf;
+		}
+		if (r->is_python)
+			argv[ai++] = "python3";
+		argv[ai++] = r->path;
+		argv[ai] = NULL;
+
+		execvp(argv[0], (char *const *)argv);
+		_exit(127);
+	}
+
+	/* parent */
+	close(r->out_fd);
+	close(r->err_fd);
+	r->out_fd = r->err_fd = -1;
+	r->pid = pid;
+	r->dispatched = true;
+}
+
+
+/* -- parent reap ----------------------------------------------------- */
+
+/*
+ * Wait for any one child to complete.  Find its
+ * test_result by pid, record exit code + elapsed, mark
+ * reaped.  Returns the index of the completed test, or
+ * -1 if no child was outstanding.
+ */
+static ssize_t reap_one(struct test_result *tests, size_t n_tests)
+{
+	int status;
+	const pid_t pid = waitpid(-1, &status, 0);
+	if (pid < 0) {
+		if (errno == ECHILD)
+			return -1;
+		die("waitpid");
+	}
+	struct timespec t1;
+	clock_gettime(CLOCK_MONOTONIC, &t1);
+
+	for (size_t i = 0; i < n_tests; i++) {
+		if (!tests[i].dispatched || tests[i].reaped)
+			continue;
+		if (tests[i].pid != pid)
+			continue;
+		tests[i].elapsed =
+			(double)(t1.tv_sec - tests[i].t0.tv_sec)
+			+ (double)(t1.tv_nsec - tests[i].t0.tv_nsec) * 1e-9;
+		if (WIFEXITED(status))
+			tests[i].exit_code = WEXITSTATUS(status);
+		else if (WIFSIGNALED(status))
+			tests[i].exit_code = 128 + WTERMSIG(status);
+		else
+			tests[i].exit_code = -1;
+		tests[i].passed = (tests[i].exit_code == 0);
+		tests[i].reaped = true;
+		return (ssize_t)i;
+	}
+	/* Should not happen: kernel handed us a pid we
+	 * never spawned.  Surface it loudly. */
+	die("waitpid returned unknown pid %d", (int)pid);
+}
+
+
+/* -- output ---------------------------------------------------------- */
+
+/* ANSI sequences; emitted only when opts->color is on. */
+#define ANSI_GREEN "\x1b[32m"
+#define ANSI_RED   "\x1b[31m"
+#define ANSI_DIM   "\x1b[2m"
+#define ANSI_RESET "\x1b[0m"
+
+/*
+ * Width of the longest effective name across `tests`,
+ * used to align the dot padding so the status column
+ * lines up visually.
+ */
+static size_t name_column_width(const struct test_result *tests, size_t n)
+{
+	size_t w = 0;
+	for (size_t i = 0; i < n; i++) {
+		const size_t len = strlen(tests[i].name) + 2; /* `t-` */
+		if (len > w)
+			w = len;
+	}
+	return w;
+}
+
+/*
+ * Print one test's status line.  The format is
+ *
+ *     test <name> <dots> <verdict> (<elapsed>s)
+ *
+ * with the dot run padding `name` out to `name_col`
+ * columns + 4 minimum dots.
+ */
+static void print_status(const struct test_result *r, const struct opts *o,
+	size_t name_col)
+{
+	const char *g_on = o->color ? ANSI_GREEN : "";
+	const char *r_on = o->color ? ANSI_RED   : "";
+	const char *d_on = o->color ? ANSI_DIM   : "";
+	const char *off  = o->color ? ANSI_RESET : "";
+
+	const size_t name_len = strlen(r->name) + 2; /* "t-" */
+	const size_t dots = (name_col >= name_len)
+		? (name_col - name_len) + 4 : 4;
+
+	printf("test t-%s ", r->name);
+	fputs(d_on, stdout);
+	for (size_t i = 0; i < dots; i++)
+		fputc('.', stdout);
+	fputs(off, stdout);
+	if (r->passed)
+		printf(" %sok%s", g_on, off);
+	else
+		printf(" %sFAILED%s", r_on, off);
+	printf(" %s(%.2fs)%s\n", d_on, r->elapsed, off);
+	fflush(stdout);
+}
+
+/*
+ * Dump a file by path with a labelled header.  Used to
+ * surface captured stdout / stderr of a failed test.
+ * Silently skips empty files.
+ */
+static void dump_file(const char *label, const char *path)
+{
+	struct stat st;
+	if (stat(path, &st) < 0 || st.st_size == 0)
+		return;
+	printf("---- %s ----\n", label);
+	FILE *f = fopen(path, "r");
+	if (!f) {
+		printf("(could not open %s: %s)\n", path, strerror(errno));
+		return;
+	}
+	char buf[4096];
+	size_t r, total = 0;
+	int last_ch = '\n';
+	while ((r = fread(buf, 1, sizeof buf, f)) > 0) {
+		fwrite(buf, 1, r, stdout);
+		total += r;
+		last_ch = (unsigned char)buf[r - 1];
+	}
+	fclose(f);
+	if (total > 0 && last_ch != '\n')
+		fputc('\n', stdout);
+}
+
+/*
+ * After the run completes, print captured output of
+ * each failed test, the by-subsystem rollup, and the
+ * final pass/fail summary line.
+ */
+static int print_summary(const struct test_result *tests, size_t n_tests,
+	double total, const struct opts *o)
+{
+	const char *g_on = o->color ? ANSI_GREEN : "";
+	const char *r_on = o->color ? ANSI_RED   : "";
+	const char *d_on = o->color ? ANSI_DIM   : "";
+	const char *off  = o->color ? ANSI_RESET : "";
+
+	size_t passed = 0, failed = 0;
+	for (size_t i = 0; i < n_tests; i++) {
+		if (tests[i].passed)
+			passed++;
+		else
+			failed++;
+	}
+
+	if (failed > 0) {
+		printf("\nfailures:\n\n");
+		for (size_t i = 0; i < n_tests; i++) {
+			if (tests[i].passed)
+				continue;
+			char buf[128];
+			snprintf(buf, sizeof buf, "t-%s stdout",
+				tests[i].name);
+			dump_file(buf, tests[i].out_path);
+			snprintf(buf, sizeof buf, "t-%s stderr",
+				tests[i].name);
+			dump_file(buf, tests[i].err_path);
+			printf("(exit %d)\n\n", tests[i].exit_code);
+		}
+		printf("failures:\n");
+		for (size_t i = 0; i < n_tests; i++) {
+			if (!tests[i].passed)
+				printf("    t-%s\n", tests[i].name);
+		}
+	}
+
+	/* By-subsystem rollup: count passes + fails per
+	 * unique subsys.  O(n^2) over a tiny n -- no need
+	 * for a hash. */
+	printf("\nby subsystem:\n");
+	bool printed[256] = { 0 };
+	for (size_t i = 0; i < n_tests; i++) {
+		if (printed[i])
+			continue;
+		size_t p = 0, f = 0;
+		for (size_t j = i; j < n_tests; j++) {
+			if (printed[j])
+				continue;
+			if (strcmp(tests[j].subsys, tests[i].subsys) != 0)
+				continue;
+			printed[j] = true;
+			if (tests[j].passed)
+				p++;
+			else
+				f++;
+		}
+		const char *col = (f > 0) ? r_on : g_on;
+		printf("  %-20s %s%zu passed%s",
+			tests[i].subsys, col, p, off);
+		if (f > 0)
+			printf("  %s(%zu/%zu failed)%s", r_on, f, p + f, off);
+		fputc('\n', stdout);
+	}
+
+	const char *verdict_col = (failed == 0) ? g_on : r_on;
+	const char *verdict = (failed == 0) ? "ok" : "FAILED";
+	printf("\ntest result: %s%s%s. %zu passed; %zu failed;"
+	       " %sfinished in %.2fs%s\n",
+		verdict_col, verdict, off, passed, failed,
+		d_on, total, off);
+
+	return (failed == 0) ? 0 : 1;
+}
+
+
+/* -- tempdir cleanup ------------------------------------------------- */
+
+/*
+ * Remove the per-run tempdir and any files inside it.
+ * Best-effort: any errors are reported but don't escalate
+ * to a non-zero exit, since the test results matter more
+ * than tempdir hygiene.  The tempfiles named in `tests`
+ * are the only contents we ever created, so we don't need
+ * a directory walk.
+ */
+static void cleanup_tmpdir(const char *tmpdir,
+	const struct test_result *tests, size_t n_tests)
+{
+	for (size_t i = 0; i < n_tests; i++) {
+		if (tests[i].out_path)
+			unlink(tests[i].out_path);
+		if (tests[i].err_path)
+			unlink(tests[i].err_path);
+	}
+	if (rmdir(tmpdir) < 0)
+		perror("test/run: rmdir tmpdir");
+}
+
+
+/* -- main loop ------------------------------------------------------- */
+
+int main(int argc, char **argv)
+{
+	struct opts o;
+	int first_pos;
+	parse_opts(argc, argv, &o, &first_pos);
+
+	/*
+	 * HDF5 1.10+ takes an advisory flock(2) on every
+	 * file it opens; when N parallel children each
+	 * H5Fopen the same committed test fixture under
+	 * test/data/, the second-and-later opens
+	 * intermittently fail.  All our tests open
+	 * fixtures read-only, so disabling the locking
+	 * is safe and stops the parallel runs from
+	 * flaking.  Setting the env var here means every
+	 * fork+exec'd child inherits it.
+	 */
+	setenv("HDF5_USE_FILE_LOCKING", "FALSE", 0);
+
+	const int n_paths = argc - first_pos;
+	if (n_paths <= 0) {
+		fputs("test/run: no test paths supplied (after `--`)\n",
+			stderr);
+		usage(stderr);
+		exit(2);
+	}
+
+	/* Build the test_result array.  In MPI mode, Python
+	 * tests get filtered out at this stage so the user-
+	 * supplied list can be common between MPI and
+	 * non-MPI invocations. */
+	struct test_result *tests = calloc(n_paths, sizeof *tests);
+	if (!tests)
+		die("calloc");
+	size_t n_tests = 0;
+	for (int i = 0; i < n_paths; i++) {
+		const char *p = argv[first_pos + i];
+		const size_t plen = strlen(p);
+		const bool py = (plen > 3 && strcmp(p + plen - 3, ".py") == 0);
+		if (py && o.mpiranks > 0)
+			continue;
+		tests[n_tests] = (struct test_result){
+			.path = p,
+			.is_python = py,
+		};
+		tests[n_tests].name = make_name(p);
+		tests[n_tests].subsys = make_subsys(tests[n_tests].name);
+		n_tests++;
+	}
+	filter_tests(tests, &n_tests, o.filter);
+	if (n_tests == 0) {
+		fputs("test/run: no tests after filter\n", stderr);
+		exit(0);
+	}
+
+	/* Per-run tempdir for captured output. */
+	char tmpdir[] = "/tmp/phase2-test-run-XXXXXX";
+	if (!mkdtemp(tmpdir))
+		die("mkdtemp");
+
+	const size_t name_col = name_column_width(tests, n_tests);
+	printf("\nrunning %zu test%s\n\n", n_tests, n_tests == 1 ? "" : "s");
+
+	struct timespec wall0;
+	clock_gettime(CLOCK_MONOTONIC, &wall0);
+
+	/* Single bounded loop: dispatch up to `jobs` at a
+	 * time, reap as they finish, repeat until every
+	 * test has both dispatched and reaped. */
+	size_t next_pending = 0;
+	size_t running = 0;
+	while (next_pending < n_tests || running > 0) {
+		while (running < (size_t)o.jobs && next_pending < n_tests) {
+			spawn_one(&tests[next_pending], &o, tmpdir);
+			next_pending++;
+			running++;
+		}
+		if (running > 0) {
+			const ssize_t done = reap_one(tests, n_tests);
+			if (done < 0)
+				break;
+			print_status(&tests[done], &o, name_col);
+			running--;
+		}
+	}
+
+	struct timespec wall1;
+	clock_gettime(CLOCK_MONOTONIC, &wall1);
+	const double total =
+		(double)(wall1.tv_sec - wall0.tv_sec)
+		+ (double)(wall1.tv_nsec - wall0.tv_nsec) * 1e-9;
+
+	const int rc = print_summary(tests, n_tests, total, &o);
+
+	cleanup_tmpdir(tmpdir, tests, n_tests);
+	for (size_t i = 0; i < n_tests; i++) {
+		/* subsys may point into name; only free if we
+		 * allocated a separate buffer (i.e. underscore
+		 * was present in name). */
+		if (tests[i].subsys != tests[i].name)
+			free(tests[i].subsys);
+		free(tests[i].name);
+		free(tests[i].out_path);
+		free(tests[i].err_path);
+	}
+	free(tests);
+
+	return rc;
+}

--- a/test/run.c
+++ b/test/run.c
@@ -18,10 +18,6 @@
  *     ---- t-data_mpi stderr ----
  *     <captured>
  *
- *     by subsystem:
- *       data     9 passed  (1/9 failed)
- *       ...
- *
  *     test result: FAILED. 30 passed; 1 failed; \
  *         finished in 6.32s
  *
@@ -47,11 +43,6 @@
  *    (--mpiranks=N) Python tests are skipped: they are
  *    rank-0 cross-validators and don't make sense under
  *    mpirun.
- *
- *  - Subsystem is the prefix between `t-` and the next
- *    `_` (or the rest of the name if no underscore):
- *    t-data_mpi.c -> "data"; t-paulis.c -> "paulis".
- *    Used for the by-subsystem rollup at the end.
  *
  *  - Colour is on iff stdout is a TTY (or FORCE_COLOR is
  *    set).  --no-color forces plain output.  The plain
@@ -219,8 +210,6 @@ struct test_result {
 	const char *path;	/* exactly as supplied on argv */
 	char *name;		/* basename(path) minus t- prefix
 				 * and .py suffix; owned */
-	char *subsys;		/* prefix of name up to first `_`;
-				 * owned (substring of name) */
 	bool is_python;		/* path ends in `.py` */
 	bool dispatched;	/* spawned? */
 	bool reaped;		/* completed and recorded? */
@@ -260,28 +249,6 @@ static char *make_name(const char *path)
 	out[cut] = '\0';
 	return out;
 }
-
-/*
- * Subsystem = the prefix of the effective name up to
- * the first `_`.  Falls back to the whole name when
- * there's no underscore (e.g. "paulis", "world").  The
- * returned pointer is a substring of `name`; lifetime
- * follows it.
- */
-static char *make_subsys(char *name)
-{
-	const char *under = strchr(name, '_');
-	if (!under)
-		return name;
-	const size_t cut = (size_t)(under - name);
-	char *out = malloc(cut + 1);
-	if (!out)
-		die("malloc");
-	memcpy(out, name, cut);
-	out[cut] = '\0';
-	return out;
-}
-
 
 /* -- filtering ------------------------------------------------------- */
 
@@ -527,8 +494,8 @@ static void dump_file(const char *label, const char *path)
 
 /*
  * After the run completes, print captured output of
- * each failed test, the by-subsystem rollup, and the
- * final pass/fail summary line.
+ * each failed test and the final pass/fail summary
+ * line.
  */
 static int print_summary(const struct test_result *tests, size_t n_tests,
 	double total, const struct opts *o)
@@ -565,34 +532,6 @@ static int print_summary(const struct test_result *tests, size_t n_tests,
 			if (!tests[i].passed)
 				printf("    t-%s\n", tests[i].name);
 		}
-	}
-
-	/* By-subsystem rollup: count passes + fails per
-	 * unique subsys.  O(n^2) over a tiny n -- no need
-	 * for a hash. */
-	printf("\nby subsystem:\n");
-	bool printed[256] = { 0 };
-	for (size_t i = 0; i < n_tests; i++) {
-		if (printed[i])
-			continue;
-		size_t p = 0, f = 0;
-		for (size_t j = i; j < n_tests; j++) {
-			if (printed[j])
-				continue;
-			if (strcmp(tests[j].subsys, tests[i].subsys) != 0)
-				continue;
-			printed[j] = true;
-			if (tests[j].passed)
-				p++;
-			else
-				f++;
-		}
-		const char *col = (f > 0) ? r_on : g_on;
-		printf("  %-20s %s%zu passed%s",
-			tests[i].subsys, col, p, off);
-		if (f > 0)
-			printf("  %s(%zu/%zu failed)%s", r_on, f, p + f, off);
-		fputc('\n', stdout);
 	}
 
 	const char *verdict_col = (failed == 0) ? g_on : r_on;
@@ -678,7 +617,6 @@ int main(int argc, char **argv)
 			.is_python = py,
 		};
 		tests[n_tests].name = make_name(p);
-		tests[n_tests].subsys = make_subsys(tests[n_tests].name);
 		n_tests++;
 	}
 	filter_tests(tests, &n_tests, o.filter);
@@ -728,11 +666,6 @@ int main(int argc, char **argv)
 
 	cleanup_tmpdir(tmpdir, tests, n_tests);
 	for (size_t i = 0; i < n_tests; i++) {
-		/* subsys may point into name; only free if we
-		 * allocated a separate buffer (i.e. underscore
-		 * was present in name). */
-		if (tests[i].subsys != tests[i].name)
-			free(tests[i].subsys);
 		free(tests[i].name);
 		free(tests[i].out_path);
 		free(tests[i].err_path);

--- a/test/run.c
+++ b/test/run.c
@@ -459,7 +459,7 @@ static void print_status(const struct test_result *r, const struct opts *o,
 		printf(" %sok%s", g_on, off);
 	else
 		printf(" %sFAILED%s", r_on, off);
-	printf(" %s(%.2fs)%s\n", d_on, r->elapsed, off);
+	printf(" %s(%.3fs)%s\n", d_on, r->elapsed, off);
 	fflush(stdout);
 }
 

--- a/test/t-circ_trott2.c
+++ b/test/t-circ_trott2.c
@@ -139,8 +139,7 @@ static void t_trotter2_mockup_sanity_check(void)
 	trotter2_mockup();
 
 	/* Two half-steps of the identity term collapse to exp(i). */
-	TEST_ASSERT(cabs(TROTT_VALS[0] - cexp(CMPLX(0.0, 1.0))) < MARGIN,
-		"trott2 mockup sanity check");
+	TEST_CNEAR(TROTT_VALS[0], cexp(CMPLX(0.0, 1.0)), MARGIN);
 }
 
 static void t_circ_trott2(size_t tag, size_t ts, size_t md, size_t ht)

--- a/test/t-circ_trott2_coeff.c
+++ b/test/t-circ_trott2_coeff.c
@@ -66,10 +66,7 @@ static void t_n4_equivalence(void)
 	const _Complex double v_md = run_trott2(
 		PH2_TESTDIR "/data/N4_multidet.h5");
 
-	TEST_ASSERT(cabs(v_cm - v_md) < MARGIN,
-		"trott2 eq: cm=%f+%fi md=%f+%fi diff=%g", creal(v_cm),
-		cimag(v_cm), creal(v_md), cimag(v_md),
-		cabs(v_cm - v_md));
+	TEST_CNEAR(v_cm, v_md, MARGIN);
 }
 
 int main(void)

--- a/test/t-circ_trott_coeff.c
+++ b/test/t-circ_trott_coeff.c
@@ -66,10 +66,7 @@ static void t_n4_equivalence(void)
 	const _Complex double v_md = run_trott(
 		PH2_TESTDIR "/data/N4_multidet.h5");
 
-	TEST_ASSERT(cabs(v_cm - v_md) < MARGIN,
-		"trott eq: cm=%f+%fi md=%f+%fi diff=%g", creal(v_cm),
-		cimag(v_cm), creal(v_md), cimag(v_md),
-		cabs(v_cm - v_md));
+	TEST_CNEAR(v_cm, v_md, MARGIN);
 }
 
 static void t_smoke(const char *src)

--- a/test/t-data_attr.c
+++ b/test/t-data_attr.c
@@ -73,9 +73,7 @@ int main(void)
 	double rd_dbl;
 	if (data_attr_read(fid, GRP_NAME, ATTR_DBL, &rd_dbl) < 0)
 		TEST_FAIL("data_attr_read double");
-	TEST_ASSERT(fabs(rd_dbl - VAL_DBL) < MARGIN,
-		"double mismatch: got %.17g, expected %.17g",
-		rd_dbl, VAL_DBL);
+	TEST_NEAR(rd_dbl, VAL_DBL, MARGIN);
 
 	data_close(fid);
 

--- a/test/t-data_coeff_matrix.c
+++ b/test/t-data_coeff_matrix.c
@@ -117,10 +117,8 @@ static void t_csf(void)
 		"csf: top-level C_alpha must be NULL (use blocks[k])");
 	TEST_ASSERT(cm.C_beta == NULL,
 		"csf: top-level C_beta must be NULL (use blocks[k])");
-	TEST_ASSERT(fabs(cm.blocks[0].cf - 0.6) < 1e-15, "csf[0].cf=%f",
-		cm.blocks[0].cf);
-	TEST_ASSERT(fabs(cm.blocks[1].cf - 0.8) < 1e-15, "csf[1].cf=%f",
-		cm.blocks[1].cf);
+	TEST_NEAR(cm.blocks[0].cf, 0.6, 1e-15);
+	TEST_NEAR(cm.blocks[1].cf, 0.8, 1e-15);
 	TEST_ASSERT(cm.blocks[0].C_alpha != NULL, "csf[0].C_alpha allocated");
 	TEST_ASSERT(cm.blocks[1].C_alpha != NULL, "csf[1].C_alpha allocated");
 

--- a/test/t-det_small.c
+++ b/test/t-det_small.c
@@ -92,8 +92,7 @@ static void t_edge_cases(void)
 	};
 	const double dU = det_small(U, 4);
 	const double exp = 2.0 * -1.0 * 5.0 * -3.0;
-	TEST_ASSERT(fabs(dU - exp) < 1e-12, "upper-triangular det, got %f",
-		dU);
+	TEST_NEAR(dU, exp, 1e-12);
 }
 
 static void t_random(uint32_t n, size_t trials)

--- a/test/t-prob.c
+++ b/test/t-prob.c
@@ -41,8 +41,7 @@ static void t_prob_cdf_uniform(void)
 			"CDF not monotone at k=%zu", k);
 
 	/* Last element must be 1.0 (within floating-point tolerance). */
-	TEST_ASSERT(fabs(cdf.y[3] - 1.0) < DBL_EPSILON,
-		"CDF last element %f != 1.0", cdf.y[3]);
+	TEST_NEAR(cdf.y[3], 1.0, DBL_EPSILON);
 
 	/* Inverse: y=0 maps to index 0. */
 	TEST_EQ(prob_cdf_inverse(&cdf, 0.0), (size_t)0);
@@ -71,8 +70,7 @@ static void t_prob_cdf_single(void)
 	TEST_EQ(prob_cdf_init(&cdf, 1), 0);
 	TEST_EQ(prob_cdf_from_iter(&cdf, iter_cb, &d), 0);
 
-	TEST_ASSERT(fabs(cdf.y[0] - 1.0) < DBL_EPSILON,
-		"single-element CDF should be 1.0");
+	TEST_NEAR(cdf.y[0], 1.0, DBL_EPSILON);
 
 	TEST_EQ(prob_cdf_inverse(&cdf, 0.0), (size_t)0);
 	TEST_EQ(prob_cdf_inverse(&cdf, 0.5), (size_t)0);
@@ -95,12 +93,9 @@ static void t_prob_cdf_known(void)
 	TEST_EQ(prob_cdf_init(&cdf, 3), 0);
 	TEST_EQ(prob_cdf_from_iter(&cdf, iter_cb, &d), 0);
 
-	TEST_ASSERT(fabs(cdf.y[0] - 0.25) < 1e-12,
-		"CDF[0] = %f, expected 0.25", cdf.y[0]);
-	TEST_ASSERT(fabs(cdf.y[1] - 0.75) < 1e-12,
-		"CDF[1] = %f, expected 0.75", cdf.y[1]);
-	TEST_ASSERT(fabs(cdf.y[2] - 1.0) < 1e-12,
-		"CDF[2] = %f, expected 1.0", cdf.y[2]);
+	TEST_NEAR(cdf.y[0], 0.25, 1e-12);
+	TEST_NEAR(cdf.y[1], 0.75, 1e-12);
+	TEST_NEAR(cdf.y[2], 1.0, 1e-12);
 
 	/* y=0.0: below all CDF values, returns 0. */
 	TEST_EQ(prob_cdf_inverse(&cdf, 0.0), (size_t)0);
@@ -136,12 +131,9 @@ static void t_prob_cdf_negative(void)
 	TEST_EQ(prob_cdf_init(&cdf, 3), 0);
 	TEST_EQ(prob_cdf_from_iter(&cdf, iter_cb, &d), 0);
 
-	TEST_ASSERT(fabs(cdf.y[0] - 0.25) < 1e-12,
-		"CDF[0] = %f, expected 0.25", cdf.y[0]);
-	TEST_ASSERT(fabs(cdf.y[1] - 0.75) < 1e-12,
-		"CDF[1] = %f, expected 0.75", cdf.y[1]);
-	TEST_ASSERT(fabs(cdf.y[2] - 1.0) < 1e-12,
-		"CDF[2] = %f, expected 1.0", cdf.y[2]);
+	TEST_NEAR(cdf.y[0], 0.25, 1e-12);
+	TEST_NEAR(cdf.y[1], 0.75, 1e-12);
+	TEST_NEAR(cdf.y[2], 1.0, 1e-12);
 
 	prob_cdf_free(&cdf);
 }

--- a/test/t-run.c
+++ b/test/t-run.c
@@ -1,0 +1,330 @@
+/*
+ * t-run -- self-tests for the parallel runner at
+ * test/run.
+ *
+ * The runner has no compile-time hooks; this test
+ * exercises it as a black box by invoking the built
+ * `./test/run` binary via popen(3) against the synthetic
+ * fixtures under `test/run-fixtures/`.  Each scenario
+ * checks the runner's two observable contracts:
+ *
+ *   - its exit code (0 iff every dispatched test
+ *     passed; 1 otherwise),
+ *   - the surface of its stdout (status line, summary
+ *     counts, failure dumps, ANSI suppression).
+ *
+ * Fixtures:
+ *   pass    exits 0
+ *   fail    exits 1
+ *   sleep   usleep(250 ms), exits 0
+ *   abort   abort() -- signal-killed (SIGABRT)
+ *   banner  writes a distinctive line to stdout AND
+ *           stderr, then exits 1
+ *
+ * The runner is invoked under `--no-color` for every
+ * case except the dedicated colour test, so the
+ * assertions can grep plain ASCII without escaping ANSI
+ * sequences.
+ */
+
+#define _POSIX_C_SOURCE 200809L
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/wait.h>
+#include <time.h>
+#include <unistd.h>
+
+#include "test.h"
+
+#ifndef PH2_TESTDIR
+#define PH2_TESTDIR "./test"
+#endif
+
+#define FIXDIR     PH2_TESTDIR "/run-fixtures"
+#define FIX_PASS   FIXDIR "/pass"
+#define FIX_FAIL   FIXDIR "/fail"
+#define FIX_SLEEP  FIXDIR "/sleep"
+#define FIX_ABORT  FIXDIR "/abort"
+#define FIX_BANNER FIXDIR "/banner"
+
+#define RUN_BIN    "./test/run"
+
+
+/* -- popen wrapper --------------------------------------------------- */
+
+struct run_out {
+	char buf[16384];	/* enough for any fixture run */
+	size_t len;
+	int exit_code;		/* normalised: WEXITSTATUS or
+				 * 128+sig, -1 on harness error */
+};
+
+/*
+ * Invoke `cmd` via popen, drain its stdout (with stderr
+ * folded in via shell `2>&1`), and report the normalised
+ * child exit status.  Used so every scenario in this
+ * file can assert against a single captured stream.
+ */
+static struct run_out run_cmd(const char *cmd)
+{
+	struct run_out r = { 0 };
+	char full[1024];
+	const int n = snprintf(full, sizeof full, "%s 2>&1", cmd);
+	TEST_ASSERT(n > 0 && (size_t)n < sizeof full,
+		"command too long: %s", cmd);
+
+	FILE *p = popen(full, "r");
+	TEST_ASSERT(p != NULL, "popen failed: %s", cmd);
+
+	size_t got;
+	while (r.len + 1 < sizeof r.buf
+	       && (got = fread(r.buf + r.len, 1,
+				sizeof r.buf - 1 - r.len, p)) > 0)
+		r.len += got;
+	r.buf[r.len] = '\0';
+
+	const int rc = pclose(p);
+	if (rc == -1)
+		r.exit_code = -1;
+	else if (WIFEXITED(rc))
+		r.exit_code = WEXITSTATUS(rc);
+	else if (WIFSIGNALED(rc))
+		r.exit_code = 128 + WTERMSIG(rc);
+	else
+		r.exit_code = -1;
+	return r;
+}
+
+/*
+ * Substring-match helper with a descriptive failure
+ * message.  Embeds (a truncated head of) the captured
+ * output so a failure makes the divergence obvious.
+ */
+static void must_contain(const struct run_out *r, const char *needle,
+	const char *what)
+{
+	if (strstr(r->buf, needle) != NULL)
+		return;
+	fprintf(stderr, "expected %s (%s) in runner output, got:\n%.2000s\n",
+		what, needle, r->buf);
+	TEST_FAIL("substring %s not found", needle);
+}
+
+static void must_not_contain(const struct run_out *r, const char *needle,
+	const char *what)
+{
+	if (strstr(r->buf, needle) == NULL)
+		return;
+	fprintf(stderr, "unexpected %s (%s) in runner output:\n%.2000s\n",
+		what, needle, r->buf);
+	TEST_FAIL("substring %s should not appear", needle);
+}
+
+
+/* -- scenarios ------------------------------------------------------- */
+
+/*
+ * Single passing test -> exit 0, "ok" verdict, "1
+ * passed; 0 failed" totals.
+ */
+static void t_pass_one(void)
+{
+	struct run_out r = run_cmd(RUN_BIN " --no-color -- " FIX_PASS);
+	TEST_EQ(r.exit_code, 0);
+	must_contain(&r, "test t-pass", "status line for pass fixture");
+	must_contain(&r, " ok ", "ok verdict");
+	must_contain(&r, "1 passed; 0 failed", "summary totals");
+}
+
+/*
+ * Single failing test -> exit 1, "FAILED" verdict, "0
+ * passed; 1 failed" totals.
+ */
+static void t_fail_one(void)
+{
+	struct run_out r = run_cmd(RUN_BIN " --no-color -- " FIX_FAIL);
+	TEST_EQ(r.exit_code, 1);
+	must_contain(&r, "test t-fail", "status line for fail fixture");
+	must_contain(&r, "FAILED", "FAILED verdict");
+	must_contain(&r, "0 passed; 1 failed", "summary totals");
+	must_contain(&r, "(exit 1)", "exit code annotation");
+}
+
+/*
+ * Mixed run: pass + fail simultaneously -> exit 1, the
+ * fail is itemised under the "failures:" block.
+ */
+static void t_mixed(void)
+{
+	struct run_out r = run_cmd(RUN_BIN " --no-color --jobs=2 -- "
+		FIX_PASS " " FIX_FAIL);
+	TEST_EQ(r.exit_code, 1);
+	must_contain(&r, "1 passed; 1 failed", "mixed summary totals");
+	must_contain(&r, "failures:", "failures block header");
+	must_contain(&r, "    t-fail", "fail listed in failures block");
+}
+
+/*
+ * Signal-killed test (SIGABRT) -> runner reports exit
+ * code 128+6 = 134.
+ */
+static void t_abort_signal(void)
+{
+	struct run_out r = run_cmd(RUN_BIN " --no-color -- " FIX_ABORT);
+	TEST_EQ(r.exit_code, 1);
+	must_contain(&r, "FAILED", "abort yields FAILED verdict");
+	must_contain(&r, "(exit 134)", "SIGABRT maps to exit 134");
+}
+
+/*
+ * Failing test that wrote to both streams -> runner
+ * dumps the captured output under labelled headers.
+ */
+static void t_failure_dump(void)
+{
+	struct run_out r = run_cmd(RUN_BIN " --no-color -- " FIX_BANNER);
+	TEST_EQ(r.exit_code, 1);
+	must_contain(&r, "---- t-banner stdout ----", "stdout header");
+	must_contain(&r, "BANNER_STDOUT_LINE", "stdout body captured");
+	must_contain(&r, "---- t-banner stderr ----", "stderr header");
+	must_contain(&r, "BANNER_STDERR_LINE", "stderr body captured");
+}
+
+/*
+ * --filter narrows the set by effective name.  Pass +
+ * fail supplied, filter='pass*' -> only pass runs ->
+ * exit 0.
+ */
+static void t_filter(void)
+{
+	struct run_out r = run_cmd(RUN_BIN " --no-color --filter='pass*' -- "
+		FIX_PASS " " FIX_FAIL);
+	TEST_EQ(r.exit_code, 0);
+	must_contain(&r, "running 1 test", "filter narrows to 1");
+	must_contain(&r, "1 passed; 0 failed", "filter summary totals");
+	must_not_contain(&r, "t-fail", "fail filtered out");
+}
+
+/*
+ * --jobs=4 with 4 sleep(250 ms) tests should finish
+ * well under the 1.0 s serial bound.  Bound is loose
+ * (0.8 s) to tolerate fork/exec overhead and CI load,
+ * but tight enough to detect the runner falling back
+ * to serial execution.
+ */
+static void t_parallel_speedup(void)
+{
+	struct timespec t0, t1;
+	clock_gettime(CLOCK_MONOTONIC, &t0);
+	struct run_out r = run_cmd(RUN_BIN " --no-color --jobs=4 -- "
+		FIX_SLEEP " " FIX_SLEEP " " FIX_SLEEP " " FIX_SLEEP);
+	clock_gettime(CLOCK_MONOTONIC, &t1);
+
+	TEST_EQ(r.exit_code, 0);
+	must_contain(&r, "4 passed; 0 failed", "all four passed");
+
+	const double elapsed = (double)(t1.tv_sec - t0.tv_sec)
+		+ (double)(t1.tv_nsec - t0.tv_nsec) * 1e-9;
+	TEST_ASSERT(elapsed < 0.8,
+		"expected parallel speedup (4x usleep(250ms) "
+		"with --jobs=4), got %.2fs wall", elapsed);
+}
+
+/*
+ * --jobs=1 with the same workload should take roughly
+ * the serial time (>= 4 x 250 ms).  This is the
+ * negative of t_parallel_speedup -- proves the bound
+ * above is actually load-bearing.
+ */
+static void t_serial_no_speedup(void)
+{
+	struct timespec t0, t1;
+	clock_gettime(CLOCK_MONOTONIC, &t0);
+	struct run_out r = run_cmd(RUN_BIN " --no-color --jobs=1 -- "
+		FIX_SLEEP " " FIX_SLEEP " " FIX_SLEEP " " FIX_SLEEP);
+	clock_gettime(CLOCK_MONOTONIC, &t1);
+
+	TEST_EQ(r.exit_code, 0);
+	const double elapsed = (double)(t1.tv_sec - t0.tv_sec)
+		+ (double)(t1.tv_nsec - t0.tv_nsec) * 1e-9;
+	TEST_ASSERT(elapsed >= 0.9,
+		"--jobs=1 should run serially, got %.2fs wall "
+		"(expected >= 0.9s for 4x usleep(250ms))",
+		elapsed);
+}
+
+/*
+ * --no-color must not emit ANSI escape introducers.
+ * The runner's status line is already plain ASCII --
+ * the assertion guards against accidental introduction
+ * of escapes in some future edit.
+ */
+static void t_no_color(void)
+{
+	struct run_out r = run_cmd(RUN_BIN " --no-color -- " FIX_PASS);
+	TEST_EQ(r.exit_code, 0);
+	must_not_contain(&r, "\x1b[", "ANSI escape under --no-color");
+}
+
+/*
+ * FORCE_COLOR=1 should re-enable colour even when the
+ * stdout side of popen is a pipe (i.e. isatty false).
+ * Confirms the runner honours the env override.
+ */
+static void t_force_color(void)
+{
+	struct run_out r = run_cmd("FORCE_COLOR=1 " RUN_BIN " -- " FIX_PASS);
+	TEST_EQ(r.exit_code, 0);
+	must_contain(&r, "\x1b[32m", "green ANSI under FORCE_COLOR");
+}
+
+/*
+ * No paths after `--` is a usage error (exit 2).  Guard
+ * against the runner silently exiting 0 on an empty
+ * suite, which would mask CI invocation bugs.
+ */
+static void t_no_paths(void)
+{
+	struct run_out r = run_cmd(RUN_BIN " --no-color");
+	TEST_EQ(r.exit_code, 2);
+	must_contain(&r, "no test paths supplied", "empty-list diagnostic");
+}
+
+
+/* -- main ------------------------------------------------------------ */
+
+/*
+ * Detect a wrapping mpirun and skip: this meta-test is
+ * single-process and would otherwise have every rank
+ * popen() its own copy of ./test/run.  The runner's MPI
+ * mode does not selectively skip native tests, so the
+ * guard lives here.  OMPI_COMM_WORLD_SIZE is set by
+ * Open MPI's mpirun in every spawned child.
+ */
+static bool under_mpirun(void)
+{
+	return getenv("OMPI_COMM_WORLD_SIZE") != NULL
+		|| getenv("PMI_SIZE") != NULL;
+}
+
+int main(void)
+{
+	if (under_mpirun())
+		return 0;
+
+	t_pass_one();
+	t_fail_one();
+	t_mixed();
+	t_abort_signal();
+	t_failure_dump();
+	t_filter();
+	t_parallel_speedup();
+	t_serial_no_speedup();
+	t_no_color();
+	t_force_color();
+	t_no_paths();
+	return 0;
+}

--- a/test/t-state_prep_coeff_csf.c
+++ b/test/t-state_prep_coeff_csf.c
@@ -24,10 +24,8 @@ static void t_two_component(void)
 	struct data_coeff_matrix cm;
 	TEST_EQ(data_coeff_matrix_load(fid, &cm), 0);
 	TEST_EQ(cm.n_components, 2u);
-	TEST_ASSERT(fabs(cm.blocks[0].cf - 0.6) < 1e-15,
-		"csf coef0=%f", cm.blocks[0].cf);
-	TEST_ASSERT(fabs(cm.blocks[1].cf - 0.8) < 1e-15,
-		"csf coef1=%f", cm.blocks[1].cf);
+	TEST_NEAR(cm.blocks[0].cf, 0.6, 1e-15);
+	TEST_NEAR(cm.blocks[1].cf, 0.8, 1e-15);
 
 	struct qreg reg;
 	TEST_EQ(qreg_init(&reg, cm.nqb), 0);

--- a/test/t-state_prep_coeff_expand.c
+++ b/test/t-state_prep_coeff_expand.c
@@ -200,7 +200,7 @@ static void t_boundary_zero(void)
 		0);
 	_Complex double z;
 	qreg_getamp(&reg, 0, &z);
-	TEST_ASSERT(fabs(creal(z) - 1.0) < 1e-14, "vacuum amp[0]=%f", creal(z));
+	TEST_NEAR(creal(z), 1.0, 1e-14);
 	qreg_free(&reg);
 }
 
@@ -223,8 +223,7 @@ static void t_boundary_full(void)
 	const uint64_t target = 0xfu;
 	_Complex double z;
 	qreg_getamp(&reg, target, &z);
-	TEST_ASSERT(fabs(creal(z) - 1.0) < 1e-14, "full amp got %f+%fi",
-		creal(z), cimag(z));
+	TEST_NEAR(creal(z), 1.0, 1e-14);
 	qreg_free(&reg);
 }
 

--- a/test/t-state_prep_coeff_large.c
+++ b/test/t-state_prep_coeff_large.c
@@ -86,10 +86,8 @@ int main(void)
 	const double nsq = creal(inner);
 	fprintf(stderr, "N=14 <psi|psi>: %.6f (imag=%.2e)\n", nsq,
 		cimag(inner));
-	TEST_ASSERT(fabs(nsq - 1.0) < 1e-10,
-		"N=14 trial state not unit norm: <psi|psi>=%.12f", nsq);
-	TEST_ASSERT(fabs(cimag(inner)) < 1e-10,
-		"N=14 <psi|psi> has non-zero imag part: %.3e", cimag(inner));
+	TEST_NEAR(nsq, 1.0, 1e-10);
+	TEST_NEAR(cimag(inner), 0.0, 1e-10);
 
 	qreg_free(&reg);
 	world_free();

--- a/test/test.h
+++ b/test/test.h
@@ -5,29 +5,68 @@
 #include <stdlib.h>
 
 /*
- * __VA_OPT__ has been added to C23. It is also part of GNU C and is
- * supported by gcc.
+ * Minimal C test harness.
+ *
+ * Three core macros:
+ *   TEST_FAIL(fmt, ...)        unconditional abort with
+ *                              file:line:func and message;
+ *                              exits with non-zero status.
+ *   TEST_ASSERT(expr, fmt, ...) abort with the formatted
+ *                              message iff `expr` is false.
+ *   TEST_EQ(a, b)              shorthand for the common
+ *                              `expected a == b` check.
+ *
+ * All three macros are statements -- never use in
+ * expression position.  __VA_OPT__ keeps the comma off when
+ * the variadic list is empty (C23 / GNU C).
+ *
+ * On failure each macro emits one line to stderr in the
+ * GCC-error format:
+ *
+ *   <file>:<line>: FAIL [<func>]: <msg>
+ *
+ * so editors recognise the leading `file:line:` and jump
+ * directly to the failing source location.
+ *
+ * Conventions for new tests:
+ *
+ *   - Binaries live in `test/` and are named
+ *     `t-<subsys>[_<aspect>].c` (e.g. `t-data_hamil.c`,
+ *     `t-circ_trott_coeff.c`); the matching binary lands
+ *     under the same name, listed in the Makefile's TESTS
+ *     variable.
+ *   - Shared fixture helpers go in a per-subsystem header
+ *     (`test/t-data.h` is the canonical model -- it carries
+ *     the `TEST_DATA[]` fixture array and the
+ *     `test_fixture_copy` helper).  `test.h` itself stays
+ *     macro-only.
+ *   - Each test calls `world_init(nullptr, nullptr, SEED)`
+ *     at the top of `main` and `world_free()` before
+ *     return.  Failure path: any TEST_* macro aborts via
+ *     `exit`, so the world is left uninitialised on the
+ *     way out -- that is intentional, the OS reaps it.
  */
+
 #define TEST_FAIL(fmt, ...)                                                    \
-	({                                                                     \
-		fprintf(stderr, "%s:%d FAIL \"" fmt "\"\n", __FILE__,          \
-			__LINE__ __VA_OPT__(, ) __VA_ARGS__);                  \
+	do {                                                                   \
+		fprintf(stderr, "%s:%d: FAIL [%s]: " fmt "\n", __FILE__,       \
+			__LINE__, __func__ __VA_OPT__(, ) __VA_ARGS__);        \
 		exit(-1);                                                      \
-	})
+	} while (0)
 
 #define TEST_ASSERT(expr, fmt, ...)                                            \
-	({                                                                     \
+	do {                                                                   \
 		if (!(expr))                                                   \
 			TEST_FAIL(fmt __VA_OPT__(, ) __VA_ARGS__);             \
-	})
+	} while (0)
 
 #define TEST_STR(a) #a
 #define TEST_XSTR(a) TEST_STR(a)
 
 #define TEST_EQ(a, b)                                                          \
-	({                                                                     \
+	do {                                                                   \
 		TEST_ASSERT((a) == (b), "expected %s == %s", TEST_XSTR(a),     \
 			TEST_XSTR(b));                                         \
-	})
+	} while (0)
 
 #endif /* TEST_H */

--- a/test/test.h
+++ b/test/test.h
@@ -1,6 +1,8 @@
 #ifndef TEST_H
 #define TEST_H
 
+#include <complex.h>
+#include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
 
@@ -67,6 +69,38 @@
 	do {                                                                   \
 		TEST_ASSERT((a) == (b), "expected %s == %s", TEST_XSTR(a),     \
 			TEST_XSTR(b));                                         \
+	} while (0)
+
+/*
+ * Tolerance-based equality for doubles.  Aborts when
+ * |a - b| > eps; the failure message carries the
+ * stringified expressions plus their observed values
+ * and the violated diff.
+ */
+#define TEST_NEAR(a, b, eps)                                                   \
+	do {                                                                   \
+		const double _a = (a), _b = (b), _eps = (eps);                 \
+		if (fabs(_a - _b) > _eps)                                      \
+			TEST_FAIL("|%s - %s| = %g > %g (%g vs %g)",            \
+				TEST_XSTR(a), TEST_XSTR(b), fabs(_a - _b),     \
+				_eps, _a, _b);                                 \
+	} while (0)
+
+/*
+ * Tolerance-based equality for _Complex doubles.  Same
+ * shape as TEST_NEAR but uses cabs and prints both
+ * components on failure.
+ */
+#define TEST_CNEAR(a, b, eps)                                                  \
+	do {                                                                   \
+		const _Complex double _a = (a), _b = (b);                      \
+		const double _eps = (eps);                                     \
+		if (cabs(_a - _b) > _eps)                                      \
+			TEST_FAIL("|%s - %s| = %g > %g"                        \
+				  " ((%g+%gi) vs (%g+%gi))",                   \
+				TEST_XSTR(a), TEST_XSTR(b), cabs(_a - _b),     \
+				_eps, creal(_a), cimag(_a), creal(_b),         \
+				cimag(_b));                                    \
 	} while (0)
 
 #endif /* TEST_H */


### PR DESCRIPTION
Rework the test harness around a parallel
cargo-style runner.  Tighten the `test.h` macro
core.  Add a TESTS-list drift guard.  Write the
subsystem doc.


## Parallel runner -- `test/run`

Standalone single-file C program, libc + POSIX
only, no phase2 / MPI / HDF5 deps.  Forks up to
`--jobs=N` children (default `nproc`), captures
each child's stdout / stderr to tempfiles under a
`mkdtemp(3)` directory, reaps with `waitpid(-1)`
in arrival order, prints cargo-style status lines
with millisecond-precision per-test elapsed:

    test t-bitstring_index ............ ok (0.038s)
    test t-data_mpi ................... FAILED (1.234s)
    ...
    test result: FAILED. 30 passed; 1 failed; finished in 6.32s

Failed tests have their captured streams dumped
under `---- t-NAME stdout ----` / `---- t-NAME
stderr ----` headers before the summary.

Flags: `--jobs`, `--mpiranks` (wrap each test in
`mpirun -n N`; `.py` skipped), `--filter=GLOB`
(fnmatch against the effective test name --
basename minus `t-` prefix and `.py` suffix),
`--no-color`, `--verbose`.  TTY-aware colour
(`FORCE_COLOR=1` overrides under a pipe).  Exit
codes: 0 (all passed), 1 (any failed), 2 (usage
error).  Signal-killed children report as
`128 + signum`.  Children inherit the parent's
process group, so a `SIGINT` at the terminal
takes the run down cleanly.

The runner sets `HDF5_USE_FILE_LOCKING=FALSE` so
concurrent readers of committed fixtures don't
lose the HDF5 1.10+ advisory `flock(2)`.
Architectural detail (process model, fd plumbing,
Python and MPI wrapping) lives at the top of
`test/run.c`.


## Runner self-tests -- `test/t-run`

Black-box meta-test: shells out to `./test/run`
via `popen(3)` against five synthetic fixtures
(`pass`, `fail`, `sleep`, `abort`, `banner`)
under `test/run-fixtures/`.  Asserts exit-code
partition, `SIGABRT` -> 134, `--filter`
narrowing, `--jobs=4` speedup with a load-bearing
`--jobs=1` negative bound, `--no-color` and
`FORCE_COLOR` behaviour, failure-dump format,
and the empty-list usage error.  No-ops under
`mpirun` (single-process by design).


## test.h macro core

- `TEST_FAIL` emits `file:line: FAIL [func]: msg`
  (gcc-error format) so editors jump straight to
  the source location.
- Core macros switched from GNU
  `({ ... })` to ISO C `do { ... } while (0)`.
- New `TEST_NEAR(a, b, eps)` and `TEST_CNEAR`
  for tolerance checks on `double` and `_Complex
  double`.  ~15 in-tree call sites swept off the
  verbose `TEST_ASSERT(fabs(a-b) < eps, ...)`
  form; sites with rich loop-index context keep
  `TEST_ASSERT`.


## Makefile

`make check`, `make check-mpi MPIRANKS=N`, `make
check-slow`, and `make check-<filter>` all
delegate to `test/run`.  The `check-<filter>`
pattern target threads the stem as `<filter>*`
fnmatch into the runner, so `check-data`,
`check-paulis`, `check-circ` work with no
per-target rule.

`check-tests-coverage` is a prerequisite of
`build-test`: a `test/t-*.c` source missing from
`TESTS` / `TESTS_SLOW` fails the build, blocking
silent suite drift.

Retired: the `CHECKS` / `CHECKS_SLOW` pattern
variables and per-test `check/%` recipes, the
`check-python` target (the harness rides along
inside the unified `check`), the in-place
`mpirun` shell-for-loop in `check-mpi`, and a
commented-out `check` stub.


## Documentation

- New `doc/testing.md` (346 lines): subsystem
  reference covering layout + naming, `test.h`
  macros, per-subsystem fixture-header pattern
  (`t-data.h` as model), runner contract, Make
  integration, recipes for adding a regular test
  and a runner self-test, sanitiser / valgrind
  targets.
- `doc/phase2.md` §10 refreshed: the make-target
  table covers every `check-*` now in the
  Makefile; §10.4 keeps its by-area survey but
  hands the harness contract off to
  `doc/testing.md`.
- `README.md` Tests block updated to point at
  `check-<filter>` for subset selection and to
  link `doc/testing.md`.


## Test plan

- `make check` -- 32/32 OK (31 C tests + Python
  harness).
- `make check-mpi MPIRANKS=2` -- 30/30 OK
  (Python harness skipped under MPI; `t-run`
  no-ops under `mpirun`).
- `make check-slow` -- 1/1 OK.
- `make check-data`, `check-paulis`,
  `check-circ` filter to the expected subsets.
- Drift detection: `touch test/t-fake.c` fails
  `check-tests-coverage` with the offender
  named; revert cleans up.
- Five consecutive parallel runs all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
