### PR TITLE
build: per-subsys Makefiles, all artefacts under build/, auto-deps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,9 +66,12 @@ _deps
 
 venv
 .venv
-build/
 cmake-build-*
 tmp/
+
+# Make build artefacts (kernel-style out-of-tree
+# layout under build/<srcdir>/).
+build/
 
 Cargo.lock
 target/

--- a/.gitignore
+++ b/.gitignore
@@ -1,112 +1,24 @@
-# Prerequisites
-*.d
-
-# Object files
-*.o
-*.ko
-*.obj
-*.elf
-
-# Linker output
-*.ilk
-*.map
-*.exp
-
-# Precompiled Headers
-*.gch
-*.pch
-
-# Libraries
-*.lib
-*.a
-*.la
-*.lo
-
-# Shared objects (inc. Windows DLLs)
-*.dll
-*.so
-*.so.*
-*.dylib
-
-# Executables
-*.exe
-*.out
-*.app
-*.i*86
-*.x86_64
-*.hex
-
-# Debug files
-*.dSYM/
-*.su
-*.idb
-*.pdb
-
-# Kernel Module Compile Results
-*.mod*
-*.cmd
-.tmp_versions/
-modules.order
-Module.symvers
-Mkfile.old
-dkms.conf
-
-CMakeLists.txt.user
-CMakeCache.txt
-CMakeFiles
-CMakeScripts
-Testing
-cmake_install.cmake
-install_manifest.txt
-compile_commands.json
-CTestTestfile.cmake
-_deps
-
-*.bak
-
-venv
-.venv
-cmake-build-*
-tmp/
-
-# Make build artefacts (kernel-style out-of-tree
-# layout under build/<srcdir>/).
+# Compile artefacts -- every .o, .d, binary, and the
+# shared library lands under build/<srcdir>/.
 build/
 
-Cargo.lock
-target/
+# Editor scratch and IDE state
+*.bak
+*.swp
+.idea/
+.vscode/
 
-.idea
-.vscode
+# Python
+.venv/
+venv/
+__pycache__/
+*.egg-info/
 
+# Runtime outputs (logs, intermediate HDF5)
+*.log
 simul.log
 simul.h5*
 
-*.swp
-
-*.log
-
-ph2run/ph2run-cmpsit
-ph2run/ph2run-qdrift
-ph2run/ph2run-trott
-ph2run/ph2run
-
-bench/b-paulis
-bench/b-qreg
-
-# Test binaries: match the t-foo executable but keep
-# t-foo.c / t-foo.h / t-foo.py sources tracked.
-test/t-*
-!test/t-*.c
-!test/t-*.h
-!test/t-*.py
-
-# Parallel runner binary and its fixture binaries; the
-# fixture .c sources stay tracked.
-test/run
-test/run-fixtures/*
-!test/run-fixtures/*.c
-
-*.egg-info/
-__pycache__/
-
+# Misc local
+tmp/
+.claude/

--- a/Makefile
+++ b/Makefile
@@ -208,7 +208,7 @@ LDLIBS		+= $(MPI_LDLIBS)					\
 .PHONY: all			\
 	bench			\
 	build			\
-	bulid-bench		\
+	build-bench		\
 	build-test 		\
 	clean			\
 	check			\

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,12 @@ PHASE2DIR	:= ./phase2
 PH2RUNDIR	:= ./ph2run
 LIBDIR		:= ./lib
 
+# Out-of-tree build root.  Every .o and .d lands
+# under $(BUILDDIR)/<srcdir>/, mirroring the source
+# layout.  Final binaries still live next to their
+# sources (ph2run/ph2run, test/t-paulis, ...).
+BUILDDIR	:= ./build
+
 # If you're unsure where to find the compiled MPI libraries or headers,
 # but have OpenMPI installed in your system, you can query:
 #
@@ -75,7 +81,7 @@ BACKEND_LDLIBS	:=
 
 ifeq ($(BACKEND),qreg)
 BACKEND_N	:= 0
-BACKEND_OBJS	+= $(PHASE2DIR)/qreg_qreg.o
+BACKEND_OBJS	+= $(BUILDDIR)/phase2/qreg_qreg.o
 BACKEND_CFLAGS	+=
 BACKEND_LDFLAGS	+=
 BACKEND_LDLIBS	+=
@@ -91,20 +97,21 @@ CUDA_PREFIX	:=/usr/local/cuda
 CUDA_INCLUDE	:=$(CUDA_PREFIX)/include
 CUDA_LIBDIR	:=$(CUDA_PREFIX)/lib64
 BACKEND_N	:= 2
-BACKEND_OBJS	+= $(PHASE2DIR)/qreg_cuda.o				\
-		   	$(PHASE2DIR)/qreg_cuda_lo.o			\
-			$(PHASE2DIR)/qreg_cuda_lo_dlink.o		\
-			$(PHASE2DIR)/world_cuda.o
+BACKEND_OBJS	+= $(BUILDDIR)/phase2/qreg_cuda.o			\
+		   	$(BUILDDIR)/phase2/qreg_cuda_lo.o		\
+			$(BUILDDIR)/phase2/qreg_cuda_lo_dlink.o		\
+			$(BUILDDIR)/phase2/world_cuda.o
 BACKEND_CFLAGS	+= -I$(CUDA_INCLUDE)
 BACKEND_LDFLAGS	+= -L$(CUDA_LIBDIR) -Wl,-rpath -Wl,$(CUDA_LIBDIR)
 BACKEND_LDLIBS	+= -lcudart -lstdc++
 
 NVCCFLAGS	+= $(MPI_CFLAGS) $(HDF5_CFLAGS)
-$(PHASE2DIR)/qreg_cuda_lo.o: $(PHASE2DIR)/qreg_cuda_lo.cu
+$(BUILDDIR)/phase2/qreg_cuda_lo.o: $(PHASE2DIR)/qreg_cuda_lo.cu
+	@$(MKDIR) $(@D)
 	$(NVCC) $(NVCCFLAGS) $(BACKEND_CFLAGS) 				\
 	       -I$(INCLUDE) -c $< -o $@
 
-$(PHASE2DIR)/qreg_cuda_lo_dlink.o: $(PHASE2DIR)/qreg_cuda_lo.o
+$(BUILDDIR)/phase2/qreg_cuda_lo_dlink.o: $(BUILDDIR)/phase2/qreg_cuda_lo.o
 	$(NVCC) $(NVCCFLAGS) -dlink $< -o $@
 
 endif
@@ -119,35 +126,49 @@ BACKEND_CFLAGS	+= -DPHASE2_BACKEND=$(BACKEND_N)
 # object-set unions, inter-target link prereqs, and
 # generated-header prereqs (none today).
 
-PHASE2OBJS	:= $(PHASE2DIR)/circ.o					\
-			$(PHASE2DIR)/circ_cache.o			\
-			$(PHASE2DIR)/paulis.o				\
-			$(PHASE2DIR)/prob.o				\
-			$(PHASE2DIR)/qreg.o				\
-			$(PHASE2DIR)/state_prep_coeff.o			\
-			$(PHASE2DIR)/world.o				\
+PHASE2OBJS	:= $(BUILDDIR)/phase2/circ.o				\
+			$(BUILDDIR)/phase2/circ_cache.o			\
+			$(BUILDDIR)/phase2/paulis.o			\
+			$(BUILDDIR)/phase2/prob.o			\
+			$(BUILDDIR)/phase2/qreg.o			\
+			$(BUILDDIR)/phase2/state_prep_coeff.o		\
+			$(BUILDDIR)/phase2/world.o			\
 			$(BACKEND_OBJS)
 
-PH2RUN_DATA_OBJS := $(PH2RUNDIR)/data.o
+PH2RUN_DATA_OBJS := $(BUILDDIR)/ph2run/data.o
 
-CIRCOBJS	:= $(CIRCDIR)/cmpsit.o					\
-			$(CIRCDIR)/qdrift.o				\
-			$(CIRCDIR)/trott.o				\
-			$(CIRCDIR)/trott2.o
+CIRCOBJS	:= $(BUILDDIR)/circ/cmpsit.o				\
+			$(BUILDDIR)/circ/qdrift.o			\
+			$(BUILDDIR)/circ/trott.o			\
+			$(BUILDDIR)/circ/trott2.o
 
-LIBOBJS		:= $(LIBDIR)/combinations.o				\
-			$(LIBDIR)/det_small.o				\
-			$(LIBDIR)/log.o					\
-			$(LIBDIR)/xoshiro256ss.o
+LIBOBJS		:= $(BUILDDIR)/lib/combinations.o			\
+			$(BUILDDIR)/lib/det_small.o			\
+			$(BUILDDIR)/lib/log.o				\
+			$(BUILDDIR)/lib/xoshiro256ss.o
+
+# Generic compile rules.  Two variants:
+#  - $(BUILDDIR)/%.o:  regular objects.
+#  - $(BUILDDIR)/shared/%.o:  same sources rebuilt
+#    with -fPIC on a disjoint path, so the shared
+#    library does not race the regular build's
+#    objects.
+$(BUILDDIR)/%.o: %.c
+	@$(MKDIR) $(@D)
+	$(CC) $(CFLAGS) -c $< -o $@
+
+$(BUILDDIR)/shared/%.o: %.c
+	@$(MKDIR) $(@D)
+	$(CC) $(CFLAGS) -fPIC -c $< -o $@
 
 
 # Applications
 PROGS		:=  $(PH2RUNDIR)/ph2run
 
-$(PH2RUNDIR)/ph2run: $(CIRCDIR)/trott.o					\
-			$(CIRCDIR)/trott2.o				\
-			$(CIRCDIR)/qdrift.o				\
-			$(CIRCDIR)/cmpsit.o
+$(PH2RUNDIR)/ph2run: $(BUILDDIR)/circ/trott.o				\
+			$(BUILDDIR)/circ/trott2.o			\
+			$(BUILDDIR)/circ/qdrift.o			\
+			$(BUILDDIR)/circ/cmpsit.o
 
 $(PROGS):	$(PHASE2OBJS)						\
 			$(LIBOBJS)					\
@@ -201,8 +222,11 @@ build: $(PROGS)
 SHARED_LDFLAGS	:= $(MPI_LDFLAGS) $(BACKEND_LDFLAGS)
 SHARED_LDLIBS	:= $(MPI_LDLIBS) $(BACKEND_LDLIBS)
 
-shared: CFLAGS += -fPIC
-shared: $(PHASE2DIR)/phase2_run.o $(PHASE2OBJS) $(LIBOBJS)
+SHARED_OBJS	:= $(BUILDDIR)/shared/phase2/phase2_run.o		\
+		   $(patsubst $(BUILDDIR)/%, $(BUILDDIR)/shared/%,	\
+			$(PHASE2OBJS) $(LIBOBJS))
+
+shared: $(SHARED_OBJS)
 	$(CC) -shared -o libphase2.so $^ $(SHARED_LDFLAGS) $(SHARED_LDLIBS)
 
 # --------------------------------------------------------------------------- #
@@ -215,7 +239,7 @@ BENCHES		:= $(BENCHDIR)/b-paulis					\
 			$(BENCHDIR)/b-qreg
 
 $(BENCHES):	$(BENCHDIR)/bench.h					\
-		$(BENCHDIR)/bench.o					\
+		$(BUILDDIR)/bench/bench.o				\
 		$(PHASE2OBJS) $(LIBOBJS) $(PH2RUN_DATA_OBJS)
 
 build-bench: $(BENCHES)
@@ -298,11 +322,11 @@ $(TESTS) $(TESTS_SLOW):	$(TESTDIR)/test.h				\
 			$(TESTDIR)/t-data.h				\
 			$(PHASE2OBJS) $(LIBOBJS) $(PH2RUN_DATA_OBJS)
 
-$(TESTDIR)/t-circ_cache: $(CIRCDIR)/trott.o
-$(TESTDIR)/t-circ_trott: $(CIRCDIR)/trott.o
-$(TESTDIR)/t-circ_trott2: $(CIRCDIR)/trott2.o
-$(TESTDIR)/t-circ_trott_coeff: $(CIRCDIR)/trott.o
-$(TESTDIR)/t-circ_trott2_coeff: $(CIRCDIR)/trott2.o
+$(TESTDIR)/t-circ_cache: $(BUILDDIR)/circ/trott.o
+$(TESTDIR)/t-circ_trott: $(BUILDDIR)/circ/trott.o
+$(TESTDIR)/t-circ_trott2: $(BUILDDIR)/circ/trott2.o
+$(TESTDIR)/t-circ_trott_coeff: $(BUILDDIR)/circ/trott.o
+$(TESTDIR)/t-circ_trott2_coeff: $(BUILDDIR)/circ/trott2.o
 
 build-test: check-tests-coverage $(TESTS) $(TESTDIR)/run
 
@@ -427,12 +451,8 @@ check-%: build-test
 # --------------------------------------------------------------------------- #
 
 clean:
-	@$(RM) $(CIRCDIR)/*.o $(CIRCDIR)/*.d
-	@$(RM) $(BENCHDIR)/*.o $(BENCHDIR)/*.d
-	@$(RM) $(LIBDIR)/*.o $(LIBDIR)/*.d
-	@$(RM) $(PH2RUNDIR)/*.o $(PH2RUNDIR)/*.d
-	@$(RM) $(PHASE2DIR)/*.o $(PHASE2DIR)/*.d
-	@$(RM) $(TESTDIR)/*.o $(TESTDIR)/*.d
+	@$(RM) -r $(BUILDDIR)
+	@$(RM) $(TESTDIR)/*.d
 
 distclean: clean
 	@$(RM) $(BENCHES)
@@ -462,9 +482,5 @@ format:
 # the first build.                                                            #
 # --------------------------------------------------------------------------- #
 
--include $(wildcard $(CIRCDIR)/*.d		\
-		$(BENCHDIR)/*.d			\
-		$(LIBDIR)/*.d			\
-		$(PH2RUNDIR)/*.d		\
-		$(PHASE2DIR)/*.d		\
-		$(TESTDIR)/*.d)
+-include $(shell find $(BUILDDIR) -name '*.d' 2>/dev/null)
+-include $(wildcard $(TESTDIR)/*.d)

--- a/Makefile
+++ b/Makefile
@@ -1,527 +1,337 @@
-# --------------------------------------------------------------------------- #
-# Configuration                                                               #
-#                                                                             #
-# Specify compile flags and the path to both MPI and HDF5 dynamic libraries   #
-# and headers.                                                                #
-# ----------------------------------------------------------------------------#
-VERSION_MAJOR	:= 1
-VERSION_MINOR	:= 1
-VERSION_PATCH	:= 0
-
-AS		:= nasm
-ASFLAGS		+= -felf64 -w+all -w-reloc-rel-dword -Ox
-CC		?= gcc
-CFLAGS		+= -std=c11 -Wall -Wextra -O3 -march=native -mavx2 -MMD -MP
-# EXTRA_CFLAGS / EXTRA_LDFLAGS allow command-line overrides
-# (e.g. for sanitizer builds) without clobbering the rest of
-# the build flag pipeline.
-EXTRA_CFLAGS	?=
-EXTRA_LDFLAGS	?=
-CFLAGS		+= $(EXTRA_CFLAGS)
-INCLUDE		:= ./include
-LDFLAGS 	+= $(EXTRA_LDFLAGS)
-LDLIBS		+= -lm
-LIB64		:= /usr/lib/x86_64-linux-gnu
-
-MPIRUN		:= mpirun
-MPIFLAGS	:=
-MPIRANKS	?= 2
-
-RM		= rm -fv
-MKDIR		= mkdir -p
+# ========================================================================== #
+#                                                                            #
+#   phase2 -- top-level build orchestrator                                   #
+#                                                                            #
+#   Three sections below:                                                    #
+#     1. USER CONFIGURATION -- toolchain, library paths, backend.            #
+#     2. INTERNAL           -- subsystem layout, derived vars, exports.      #
+#     3. TARGETS            -- dispatch + high-level user-facing targets.    #
+#                                                                            #
+#   Per-subsystem build rules live in $(SUBSYS)/Makefile.  Shared compile    #
+#   patterns live in build-rules.mk.  A user porting phase2 to a new        #
+#   machine edits Section 1 only.                                           #
+#                                                                            #
+# ========================================================================== #
 
 
-# --------------------------------------------------------------------------- #
-# Build dependencies                                                          #
-# --------------------------------------------------------------------------- #
-CIRCDIR		:= ./circ
-PHASE2DIR	:= ./phase2
-PH2RUNDIR	:= ./ph2run
-LIBDIR		:= ./lib
+# ========================================================================== #
+# Section 1: USER CONFIGURATION                                              #
+# ========================================================================== #
+# Edit values below to match your toolchain and library install paths.       #
+# No edits should be needed elsewhere in this Makefile (or in the           #
+# per-subsystem Makefiles) for a typical port.                              #
+# -------------------------------------------------------------------------- #
 
-# Out-of-tree build root.  Every .o and .d lands
-# under $(BUILDDIR)/<srcdir>/, mirroring the source
-# layout.  Final binaries still live next to their
-# sources (ph2run/ph2run, test/t-paulis, ...).
-BUILDDIR	:= ./build
+# --- Toolchain ------------------------------------------------------------- #
+CC              ?= gcc
+CFLAGS          += -std=c11 -Wall -Wextra -O3 -march=native -mavx2 -MMD -MP
+# EXTRA_CFLAGS / EXTRA_LDFLAGS allow command-line overrides (e.g. sanitiser
+# builds) without clobbering the rest of the flag pipeline.
+EXTRA_CFLAGS    ?=
+EXTRA_LDFLAGS   ?=
 
-# If you're unsure where to find the compiled MPI libraries or headers,
-# but have OpenMPI installed in your system, you can query:
-#
-# $ mpicc -showme
-#
-MPI_CFLAGS	:= -I$(LIB64)/openmpi/include
-MPI_LDFLAGS	:= -L$(LIB64)/openmpi/lib
-MPI_LDLIBS	:= -lmpi
+# --- System library root --------------------------------------------------- #
+# Most Debian/Ubuntu installs put MPI and HDF5 dynamic libs under
+# /usr/lib/x86_64-linux-gnu.  Adjust if your distro differs.
+LIB64           := /usr/lib/x86_64-linux-gnu
 
-# Standard (serial) HDF5.  Find the correct paths via:
-#
-# $ h5cc -shlib -show
-#
-HDF5_CFLAGS	:= -I/usr/include/hdf5/serial
-HDF5_LDFLAGS	:= -L$(LIB64)/hdf5/serial -Wl,-rpath -Wl,$(LIB64)/hdf5/serial
-HDF5_LDLIBS	:= -lhdf5 -lhdf5_hl -lcurl -lsz -lz -ldl -lm
+# --- MPI ------------------------------------------------------------------- #
+# Default: OpenMPI from the system package.  Query paths via `mpicc -showme`
+# if your install lives elsewhere.
+MPI_CFLAGS      := -I$(LIB64)/openmpi/include
+MPI_LDFLAGS     := -L$(LIB64)/openmpi/lib
+MPI_LDLIBS      := -lmpi
+MPIRUN          := mpirun
+MPIFLAGS        :=
+MPIRANKS        ?= 2
 
-# Backends
-#
-# You can specify which backend the qreg API should use.  Available options
-# are (case-sensitive):
-#
-# 	* qreg      - native engine
-#	* cuda      - NVIDIA GPU driver and runtime
-#
-# See below for how to specify the dependencies.
-BACKEND		:= qreg
-#BACKEND	:= cuda
+# --- HDF5 (serial) --------------------------------------------------------- #
+# Query paths via `h5cc -shlib -show` if unsure.
+HDF5_CFLAGS     := -I/usr/include/hdf5/serial
+HDF5_LDFLAGS    := -L$(LIB64)/hdf5/serial -Wl,-rpath -Wl,$(LIB64)/hdf5/serial
+HDF5_LDLIBS     := -lhdf5 -lhdf5_hl -lcurl -lsz -lz -ldl -lm
 
-BACKEND_OBJS	:=
-BACKEND_CFLAGS	:=
-BACKEND_LDFLAGS	:=
-BACKEND_LDLIBS	:=
+# --- Backend (qreg = CPU, cuda = NVIDIA GPU) ------------------------------- #
+BACKEND         := qreg
+# CUDA toolkit path (only relevant when BACKEND=cuda).
+CUDA_PREFIX     ?= /usr/local/cuda
+NVCC            ?= nvcc
+NVCCFLAGS       += -O3 -dopt=on -arch=native
+# Compile for NVIDIA H100 instead of the build host:
+#NVCCFLAGS       += -O3 -dopt=on -arch=sm_90a
+
+# --- Build output ---------------------------------------------------------- #
+# Every .o and .d lands under $(BUILDDIR)/<srcdir>/, mirroring the source
+# tree.  Final binaries stay next to their sources (ph2run/ph2run, ...).
+BUILDDIR        := $(CURDIR)/build
+
+# --- Version --------------------------------------------------------------- #
+VERSION_MAJOR   := 1
+VERSION_MINOR   := 1
+VERSION_PATCH   := 0
+VERSION         := $(VERSION_MAJOR).$(VERSION_MINOR).$(VERSION_PATCH)
+
+
+# ========================================================================== #
+# Section 2: INTERNAL                                                        #
+# ========================================================================== #
+# Derived variables, subsystem layout, and the export contract that makes   #
+# values from Section 1 visible to per-subsystem Makefiles.  Edit only when #
+# adding or removing a subsystem.                                           #
+# -------------------------------------------------------------------------- #
+
+# --- Tree layout ----------------------------------------------------------- #
+TOPDIR          := $(CURDIR)
+INCLUDE         := $(TOPDIR)/include
+CIRCDIR         := $(TOPDIR)/circ
+PHASE2DIR       := $(TOPDIR)/phase2
+LIBDIR          := $(TOPDIR)/lib
+PH2RUNDIR       := $(TOPDIR)/ph2run
+BENCHDIR        := $(TOPDIR)/bench
+TESTDIR         := $(TOPDIR)/test
+
+# --- Backend-conditional objects + flags ----------------------------------- #
+BACKEND_OBJS    :=
+BACKEND_CFLAGS  :=
+BACKEND_LDFLAGS :=
+BACKEND_LDLIBS  :=
 
 ifeq ($(BACKEND),qreg)
-BACKEND_N	:= 0
-BACKEND_OBJS	+= $(BUILDDIR)/phase2/qreg_qreg.o
-BACKEND_CFLAGS	+=
-BACKEND_LDFLAGS	+=
-BACKEND_LDLIBS	+=
+BACKEND_N       := 0
+BACKEND_OBJS    += $(BUILDDIR)/phase2/qreg_qreg.o
 endif
 
 ifeq ($(BACKEND),cuda)
-NVCC		?= nvcc
-NVCCFLAGS	+= -O3 -dopt=on -arch=native
-## Compile for NVIDIA H100
-## https://docs.nvidia.com/cuda/hopper-compatibility-guide/index.html
-#NVCCFLAGS      += -O3 -dopt=on -arch=sm_90a
-CUDA_PREFIX	:=/usr/local/cuda
-CUDA_INCLUDE	:=$(CUDA_PREFIX)/include
-CUDA_LIBDIR	:=$(CUDA_PREFIX)/lib64
-BACKEND_N	:= 2
-BACKEND_OBJS	+= $(BUILDDIR)/phase2/qreg_cuda.o			\
-		   	$(BUILDDIR)/phase2/qreg_cuda_lo.o		\
-			$(BUILDDIR)/phase2/qreg_cuda_lo_dlink.o		\
-			$(BUILDDIR)/phase2/world_cuda.o
-BACKEND_CFLAGS	+= -I$(CUDA_INCLUDE)
-BACKEND_LDFLAGS	+= -L$(CUDA_LIBDIR) -Wl,-rpath -Wl,$(CUDA_LIBDIR)
-BACKEND_LDLIBS	+= -lcudart -lstdc++
-
-NVCCFLAGS	+= $(MPI_CFLAGS) $(HDF5_CFLAGS)
-$(BUILDDIR)/phase2/qreg_cuda_lo.o: $(PHASE2DIR)/qreg_cuda_lo.cu
-	@$(MKDIR) $(@D)
-	$(NVCC) $(NVCCFLAGS) $(BACKEND_CFLAGS) 				\
-	       -I$(INCLUDE) -c $< -o $@
-
-$(BUILDDIR)/phase2/qreg_cuda_lo_dlink.o: $(BUILDDIR)/phase2/qreg_cuda_lo.o
-	$(NVCC) $(NVCCFLAGS) -dlink $< -o $@
-
+BACKEND_N       := 2
+CUDA_INCLUDE    := $(CUDA_PREFIX)/include
+CUDA_LIBDIR     := $(CUDA_PREFIX)/lib64
+BACKEND_OBJS    += $(BUILDDIR)/phase2/qreg_cuda.o		\
+                   $(BUILDDIR)/phase2/qreg_cuda_lo.o		\
+                   $(BUILDDIR)/phase2/qreg_cuda_lo_dlink.o	\
+                   $(BUILDDIR)/phase2/world_cuda.o
+BACKEND_CFLAGS  += -I$(CUDA_INCLUDE)
+BACKEND_LDFLAGS += -L$(CUDA_LIBDIR) -Wl,-rpath -Wl,$(CUDA_LIBDIR)
+BACKEND_LDLIBS  += -lcudart -lstdc++
+NVCCFLAGS       += $(MPI_CFLAGS) $(HDF5_CFLAGS)
 endif
 
-BACKEND_CFLAGS	+= -DPHASE2_BACKEND=$(BACKEND_N)
+BACKEND_CFLAGS  += -DPHASE2_BACKEND=$(BACKEND_N)
 
-
-# Header dependencies for every compiled .c are tracked
-# automatically via -MMD/-MP (see CFLAGS below); the
-# emitted .d files are pulled in at the foot of this
-# file.  The Makefile only declares structural deps:
-# object-set unions, inter-target link prereqs, and
-# generated-header prereqs (none today).
-
-PHASE2OBJS	:= $(BUILDDIR)/phase2/circ.o				\
-			$(BUILDDIR)/phase2/circ_cache.o			\
-			$(BUILDDIR)/phase2/paulis.o			\
-			$(BUILDDIR)/phase2/prob.o			\
-			$(BUILDDIR)/phase2/qreg.o			\
-			$(BUILDDIR)/phase2/state_prep_coeff.o		\
-			$(BUILDDIR)/phase2/world.o			\
-			$(BACKEND_OBJS)
-
+# --- Object set unions ----------------------------------------------------- #
+# Each subsys's Makefile derives its own OBJS from its SRCS list; these
+# union aliases let downstream subsystems (ph2run, bench, test) reference
+# all upstream objects in one place.  Kept in sync with the SRCS lists in
+# each subsys Makefile by the per-subsys check-srcs-coverage drift guard.
+PHASE2OBJS      := $(BUILDDIR)/phase2/circ.o			\
+                   $(BUILDDIR)/phase2/circ_cache.o		\
+                   $(BUILDDIR)/phase2/paulis.o			\
+                   $(BUILDDIR)/phase2/prob.o			\
+                   $(BUILDDIR)/phase2/qreg.o			\
+                   $(BUILDDIR)/phase2/state_prep_coeff.o	\
+                   $(BUILDDIR)/phase2/world.o			\
+                   $(BACKEND_OBJS)
+CIRCOBJS        := $(BUILDDIR)/circ/cmpsit.o			\
+                   $(BUILDDIR)/circ/qdrift.o			\
+                   $(BUILDDIR)/circ/trott.o			\
+                   $(BUILDDIR)/circ/trott2.o
+LIBOBJS         := $(BUILDDIR)/lib/combinations.o		\
+                   $(BUILDDIR)/lib/det_small.o			\
+                   $(BUILDDIR)/lib/log.o			\
+                   $(BUILDDIR)/lib/xoshiro256ss.o
 PH2RUN_DATA_OBJS := $(BUILDDIR)/ph2run/data.o
 
-CIRCOBJS	:= $(BUILDDIR)/circ/cmpsit.o				\
-			$(BUILDDIR)/circ/qdrift.o			\
-			$(BUILDDIR)/circ/trott.o			\
-			$(BUILDDIR)/circ/trott2.o
+# --- CFLAGS / LDFLAGS / LDLIBS pipeline ------------------------------------ #
+CFLAGS          += -I$(INCLUDE) $(MPI_CFLAGS) $(HDF5_CFLAGS)	\
+                   $(BACKEND_CFLAGS)				\
+                   -DPHASE2_VERSION=\"$(VERSION)\"		\
+                   $(EXTRA_CFLAGS)
+LDFLAGS         += $(MPI_LDFLAGS) $(HDF5_LDFLAGS)		\
+                   $(BACKEND_LDFLAGS) $(EXTRA_LDFLAGS)
+LDLIBS          += -lm $(MPI_LDLIBS) $(HDF5_LDLIBS) $(BACKEND_LDLIBS)
 
-LIBOBJS		:= $(BUILDDIR)/lib/combinations.o			\
-			$(BUILDDIR)/lib/det_small.o			\
-			$(BUILDDIR)/lib/log.o				\
-			$(BUILDDIR)/lib/xoshiro256ss.o
+# --- Helpers --------------------------------------------------------------- #
+RM              := rm -fv
+MKDIR           := mkdir -p
 
-# Manifest of every .c / .cu source that the build
-# system knows how to compile.  Used by the
-# `check-srcs-coverage` drift guard to fail the
-# build when a new source file is added to a
-# subsystem directory but not wired into an OBJS
-# variable.
-DECLARED_SRCS	:= $(patsubst $(BUILDDIR)/%.o,%.c,			\
-			$(PHASE2OBJS) $(CIRCOBJS)			\
-			$(LIBOBJS) $(PH2RUN_DATA_OBJS))			\
-		   phase2/phase2_run.c					\
-		   ph2run/ph2run.c					\
-		   bench/bench.c					\
-		   bench/b-paulis.c bench/b-qreg.c			\
-		   phase2/qreg_cuda.c					\
-		   phase2/qreg_cuda_lo.cu				\
-		   phase2/world_cuda.c
-
-# Generic compile rules.  Two variants:
-#  - $(BUILDDIR)/%.o:  regular objects.
-#  - $(BUILDDIR)/shared/%.o:  same sources rebuilt
-#    with -fPIC on a disjoint path, so the shared
-#    library does not race the regular build's
-#    objects.
-$(BUILDDIR)/%.o: %.c
-	@$(MKDIR) $(@D)
-	$(CC) $(CFLAGS) -c $< -o $@
-
-$(BUILDDIR)/shared/%.o: %.c
-	@$(MKDIR) $(@D)
-	$(CC) $(CFLAGS) -fPIC -c $< -o $@
+# --- Export contract -- visible to every sub-make -------------------------- #
+export CC CFLAGS LDFLAGS LDLIBS NVCC NVCCFLAGS
+export TOPDIR INCLUDE BUILDDIR
+export PHASE2DIR CIRCDIR LIBDIR PH2RUNDIR BENCHDIR TESTDIR
+export PHASE2OBJS CIRCOBJS LIBOBJS PH2RUN_DATA_OBJS BACKEND_OBJS BACKEND_CFLAGS
+export BACKEND BACKEND_N
+export MPI_CFLAGS MPI_LDFLAGS MPI_LDLIBS MPIRUN MPIFLAGS MPIRANKS
+export HDF5_CFLAGS HDF5_LDFLAGS HDF5_LDLIBS
+export RM MKDIR
 
 
-# Applications
-PROGS		:=  $(PH2RUNDIR)/ph2run
+# ========================================================================== #
+# Section 3: TARGETS                                                         #
+# ========================================================================== #
 
-$(PH2RUNDIR)/ph2run: $(BUILDDIR)/circ/trott.o				\
-			$(BUILDDIR)/circ/trott2.o			\
-			$(BUILDDIR)/circ/qdrift.o			\
-			$(BUILDDIR)/circ/cmpsit.o
+.DEFAULT_GOAL := all
 
-$(PROGS):	$(PHASE2OBJS)						\
-			$(LIBOBJS)					\
-			$(PH2RUN_DATA_OBJS)
-
-# Update flags
-VERSION		:= $(VERSION_MAJOR).$(VERSION_MINOR).$(VERSION_PATCH)
-CFLAGS		+= -I$(INCLUDE)						\
-			$(MPI_CFLAGS)					\
-			$(HDF5_CFLAGS)					\
-			$(BACKEND_CFLAGS)				\
-			-DPHASE2_VERSION=\"$(VERSION)\"
-LDFLAGS		+= $(MPI_LDFLAGS)					\
-			$(HDF5_LDFLAGS)					\
-			$(BACKEND_LDFLAGS)
-LDLIBS		+= $(MPI_LDLIBS)					\
-			$(HDF5_LDLIBS)					\
-			$(BACKEND_LDLIBS)
-# --------------------------------------------------------------------------- #
-# Targets                                                                     #
-# --------------------------------------------------------------------------- #
-.DEFAULT_GOAL	:= all
-.PHONY: all			\
-	bench			\
-	build			\
-	build-bench		\
-	build-test 		\
-	clean			\
-	check			\
-	check-mpi		\
-	debug			\
-	distclean		\
-	format			\
-	shared
+.PHONY: all build debug shared						\
+	phase2 circ lib ph2run bench test-build				\
+	build-bench build-test build-test-slow				\
+	check check-mpi check-slow check-% check-srcs-coverage		\
+	check-tests-coverage						\
+	bench-run bench-mpi						\
+	clean distclean format						\
+	test-asan test-valgrind test-mpi-asan
 
 all: build build-bench build-test
 
-debug: build build-bench build-test
-debug: ASFLAGS	+= -DDEBUG -Og -Fdwarf
-debug: CFLAGS	+= -DDEBUG -g -Og
+debug: CFLAGS  += -DDEBUG -g -Og
+debug: all
 
-build: check-srcs-coverage $(PROGS)
+# --- Per-subsystem dispatch ------------------------------------------------ #
+# Each phony target invokes the matching subsys Makefile.  Dep edges
+# between them (`ph2run: phase2 circ lib`) serialise across subsystem
+# boundaries; -j parallelises inside each subsys and between independent
+# subsystems (phase2, circ, lib).
+phase2:
+	+@$(MAKE) -C $(PHASE2DIR)
 
-# --------------------------------------------------------------------------- #
-# Shared library (Python interface)                                           #
-# --------------------------------------------------------------------------- #
-# libphase2.so carries the pure compute surface only; HDF5 stays
-# on the ph2run side, so the shared object links without HDF5
-# and a Python caller can drive phase2 over ctypes without ever
-# touching an HDF5 file.
-SHARED_LDFLAGS	:= $(MPI_LDFLAGS) $(BACKEND_LDFLAGS)
-SHARED_LDLIBS	:= $(MPI_LDLIBS) $(BACKEND_LDLIBS)
+circ:
+	+@$(MAKE) -C $(CIRCDIR)
 
-SHARED_OBJS	:= $(BUILDDIR)/shared/phase2/phase2_run.o		\
-		   $(patsubst $(BUILDDIR)/%, $(BUILDDIR)/shared/%,	\
-			$(PHASE2OBJS) $(LIBOBJS))
+lib:
+	+@$(MAKE) -C $(LIBDIR)
+
+ph2run: phase2 circ lib
+	+@$(MAKE) -C $(PH2RUNDIR)
+
+bench: phase2 circ lib ph2run-data
+	+@$(MAKE) -C $(BENCHDIR)
+
+test-build: phase2 circ lib ph2run-data
+	+@$(MAKE) -C $(TESTDIR) build
+
+# Internal: build ph2run/data.o (used by tests and benches) without
+# linking the ph2run binary.
+.PHONY: ph2run-data
+ph2run-data: phase2 circ lib
+	+@$(MAKE) -C $(PH2RUNDIR) data
+
+# --- High-level aliases ---------------------------------------------------- #
+build:       check-srcs-coverage ph2run
+build-bench: bench
+build-test:  test-build
+
+build-test-slow: phase2 circ lib ph2run-data
+	+@$(MAKE) -C $(TESTDIR) build-slow
+
+# --- Shared library (libphase2.so) ----------------------------------------- #
+# Pure compute surface, no HDF5; for Python callers via ctypes.  -fPIC
+# objects build under $(BUILDDIR)/shared/<srcdir>/ on a disjoint path
+# from the regular tree, so `make build` and `make shared` cannot mix
+# PIC and non-PIC objects.
+SHARED_LDFLAGS := $(MPI_LDFLAGS) $(BACKEND_LDFLAGS)
+SHARED_LDLIBS  := $(MPI_LDLIBS) $(BACKEND_LDLIBS)
+SHARED_OBJS    := $(BUILDDIR)/shared/phase2/phase2_run.o		\
+                  $(patsubst $(BUILDDIR)/%,$(BUILDDIR)/shared/%,	\
+                             $(PHASE2OBJS) $(LIBOBJS))
 
 shared: $(SHARED_OBJS)
-	$(CC) -shared -o libphase2.so $^ $(SHARED_LDFLAGS) $(SHARED_LDLIBS)
+	$(CC) -shared -o $(TOPDIR)/libphase2.so $^		\
+	      $(SHARED_LDFLAGS) $(SHARED_LDLIBS)
 
-# --------------------------------------------------------------------------- #
-# Benchmarks                                                                  #
-# --------------------------------------------------------------------------- #
-BENCHDIR	:= ./bench
-CFLAGS		+= -I$(BENCHDIR)
+# Dispatch the -fPIC compiles into the relevant subsys's `shared` target.
+$(SHARED_OBJS): | phase2-shared lib-shared
 
-BENCHES		:= $(BENCHDIR)/b-paulis					\
-			$(BENCHDIR)/b-qreg
+.PHONY: phase2-shared lib-shared
+phase2-shared:
+	+@$(MAKE) -C $(PHASE2DIR) shared
+lib-shared:
+	+@$(MAKE) -C $(LIBDIR) shared
 
-$(BENCHES):	$(BENCHDIR)/bench.h					\
-		$(BUILDDIR)/bench/bench.o				\
-		$(PHASE2OBJS) $(LIBOBJS) $(PH2RUN_DATA_OBJS)
+# --- Tests ----------------------------------------------------------------- #
+check: test-build
+	+@$(MAKE) -C $(TESTDIR) check
 
-build-bench: $(BENCHES)
+check-mpi: test-build
+	+@$(MAKE) -C $(TESTDIR) check-mpi
 
-bench: build-bench
-	@for bb in $(BENCHES); do					\
+check-slow: build-test-slow
+	+@$(MAKE) -C $(TESTDIR) check-slow
+
+# Pattern: `make check-data` -> runner --filter='data*'.
+# Explicit targets above win over this pattern.
+check-%: test-build
+	+@$(MAKE) -C $(TESTDIR) check-$*
+
+# --- Benchmarks ------------------------------------------------------------ #
+bench-run: bench
+	@for bb in $(BENCHDIR)/b-paulis $(BENCHDIR)/b-qreg; do		\
 		./$$bb &&						\
 			echo "$$bb: OK" ||				\
- 			( echo "$$bb: FAIL"; exit 1 );			\
+			( echo "$$bb: FAIL"; exit 1 );			\
 	done
 
-bench-mpi: build-bench
-	@for bb in $(BENCHES); do					\
-		$(MPIRUN) -n $(MPIRANKS) $(MPIFLAGS) ./$$bb && 		\
+bench-mpi: bench
+	@for bb in $(BENCHDIR)/b-paulis $(BENCHDIR)/b-qreg; do		\
+		$(MPIRUN) -n $(MPIRANKS) $(MPIFLAGS) ./$$bb &&		\
 			echo "$$bb: OK" ||				\
-			( echo "$$bb: FAIL"; exit 1 );	 		\
+			( echo "$$bb: FAIL"; exit 1 );			\
 	done
 
-# --------------------------------------------------------------------------- #
-# Testing                                                                     #
-# --------------------------------------------------------------------------- #
-TESTDIR		:= ./test
-RUNFIXDIR	:= $(TESTDIR)/run-fixtures
-CFLAGS		+= -I$(TESTDIR) -I$(PHASE2DIR) -DPH2_TESTDIR=\"$(TESTDIR)\"
-
-TESTS		:= $(TESTDIR)/t-bitstring_index			\
-			$(TESTDIR)/t-circ_cache				\
-			$(TESTDIR)/t-circ_prepst_coeff			\
-			$(TESTDIR)/t-circ_trott				\
-			$(TESTDIR)/t-circ_trott2			\
-			$(TESTDIR)/t-circ_trott2_coeff			\
-			$(TESTDIR)/t-circ_trott_coeff			\
-			$(TESTDIR)/t-circ				\
-			$(TESTDIR)/t-combinations			\
-			$(TESTDIR)/t-data_attr				\
-			$(TESTDIR)/t-data_coeff_matrix			\
-			$(TESTDIR)/t-data_hamil				\
-			$(TESTDIR)/t-data_hamil_validate		\
-			$(TESTDIR)/t-data_multidet			\
-			$(TESTDIR)/t-data_open				\
-			$(TESTDIR)/t-data_dets_validate			\
-			$(TESTDIR)/t-data_idempotence			\
-			$(TESTDIR)/t-data_mpi				\
-			$(TESTDIR)/t-data_trott_steps			\
-			$(TESTDIR)/t-det_small				\
-			$(TESTDIR)/t-log				\
-			$(TESTDIR)/t-log_release			\
-			$(TESTDIR)/t-paulis				\
-			$(TESTDIR)/t-prob				\
-			$(TESTDIR)/t-qreg				\
-			$(TESTDIR)/t-ref-bendazzoli			\
-			$(TESTDIR)/t-run				\
-			$(TESTDIR)/t-state_prep_coeff_csf		\
-			$(TESTDIR)/t-state_prep_coeff_expand		\
-			$(TESTDIR)/t-world
-
-# Synthetic fixtures used by t-run to drive the runner
-# against controlled pass / fail / signal / banner
-# outcomes.  Each fixture is a tiny self-contained C
-# program with no phase2 / MPI / HDF5 deps.
-RUNFIX		:= $(RUNFIXDIR)/pass					\
-			$(RUNFIXDIR)/fail				\
-			$(RUNFIXDIR)/sleep				\
-			$(RUNFIXDIR)/abort				\
-			$(RUNFIXDIR)/banner
-
-$(RUNFIXDIR)/%: $(RUNFIXDIR)/%.c
-	$(CC) -std=c11 -Wall -Wextra -O2 -o $@ $<
-
-# t-run is a meta-test: it shells out to ./test/run, so
-# both the runner and its fixtures must exist before
-# t-run is invoked.  Use order-only prereqs (after `|`)
-# so the implicit %: %.c link line does not try to feed
-# the runner / fixture binaries to ld.
-$(TESTDIR)/t-run: | $(TESTDIR)/run $(RUNFIX)
-
-TESTS_SLOW	:= $(TESTDIR)/t-state_prep_coeff_large
-
-$(TESTS) $(TESTS_SLOW):	$(TESTDIR)/test.h				\
-			$(TESTDIR)/t-data.h				\
-			$(PHASE2OBJS) $(LIBOBJS) $(PH2RUN_DATA_OBJS)
-
-$(TESTDIR)/t-circ_cache: $(BUILDDIR)/circ/trott.o
-$(TESTDIR)/t-circ_trott: $(BUILDDIR)/circ/trott.o
-$(TESTDIR)/t-circ_trott2: $(BUILDDIR)/circ/trott2.o
-$(TESTDIR)/t-circ_trott_coeff: $(BUILDDIR)/circ/trott.o
-$(TESTDIR)/t-circ_trott2_coeff: $(BUILDDIR)/circ/trott2.o
-
-build-test: check-tests-coverage $(TESTS) $(TESTDIR)/run
-
-# Parallel cargo-style runner.  Standalone C binary, no
-# phase2 / MPI / HDF5 dependencies.  Build with the test
-# CFLAGS so any DEBUG / sanitiser flags apply consistently.
-$(TESTDIR)/run: $(TESTDIR)/run.c
-	$(CC) -std=c11 -Wall -Wextra -O2 -o $@ $<
-
-# Guard against a t-*.c file being added to test/ but
-# forgotten in TESTS / TESTS_SLOW above -- a silent
-# omission would otherwise produce a partial suite that
-# CI cannot tell from a full one.
-.PHONY: check-tests-coverage
-check-tests-coverage:
-	@tmp=$$(mktemp -d);					\
-	ls $(TESTDIR)/t-*.c 2>/dev/null				\
-		| sed 's|\.c$$||' | sort > $$tmp/expected;	\
-	for t in $(TESTS) $(TESTS_SLOW); do echo $$t; done	\
-		| sort > $$tmp/declared;			\
-	missing=$$(comm -23 $$tmp/expected $$tmp/declared);	\
-	rc=0;							\
-	if [ -n "$$missing" ]; then				\
-		echo "test/: t-*.c files not in TESTS:";	\
-		echo "$$missing";				\
-		rc=1;						\
-	fi;							\
-	rm -rf $$tmp;						\
-	exit $$rc
-
-# Drift guard for the subsystem source dirs (phase2,
-# circ, lib, ph2run, bench).  Enumerate every .c /
-# .cu in those directories and verify each appears
-# in DECLARED_SRCS.  A new source dropped into one
-# of them but not wired into an OBJS variable fails
-# the build immediately.
-.PHONY: check-srcs-coverage
+# --- Drift guards ---------------------------------------------------------- #
+# Each subsys checks its own *.c/*.cu against its own SRCS list.
 check-srcs-coverage:
-	@tmp=$$(mktemp -d);					\
-	ls phase2/*.c phase2/*.cu				\
-	   circ/*.c lib/*.c ph2run/*.c bench/*.c		\
-	   2>/dev/null | sort > $$tmp/expected;			\
-	for s in $(DECLARED_SRCS); do echo $$s; done		\
-		| sort -u > $$tmp/declared;			\
-	missing=$$(comm -23 $$tmp/expected $$tmp/declared);	\
-	rc=0;							\
-	if [ -n "$$missing" ]; then				\
-		echo "build: .c sources not in DECLARED_SRCS:";	\
-		echo "$$missing";				\
-		rc=1;						\
-	fi;							\
-	rm -rf $$tmp;						\
-	exit $$rc
+	+@$(MAKE) -C $(PHASE2DIR) check-srcs-coverage
+	+@$(MAKE) -C $(CIRCDIR)   check-srcs-coverage
+	+@$(MAKE) -C $(LIBDIR)    check-srcs-coverage
+	+@$(MAKE) -C $(PH2RUNDIR) check-srcs-coverage
+	+@$(MAKE) -C $(BENCHDIR)  check-srcs-coverage
 
-# Tests are always built with -DDEBUG so log_trace /
-# log_debug in include/log.h expand to real emits.
-# t-log_release cancels this so the release-build strip
-# of trace/debug macros can be verified end-to-end --
-# the override must come after the blanket -DDEBUG so
-# the trailing -UDEBUG wins on the gcc command line.
-$(TESTS): CFLAGS += -DDEBUG -g -Og
-$(TESTDIR)/t-log_release: CFLAGS += -UDEBUG
+check-tests-coverage:
+	+@$(MAKE) -C $(TESTDIR) check-tests-coverage
 
-# All check targets delegate to test/run; the runner
-# fans the suite out across cores, captures per-test
-# stdout/stderr, and prints a cargo-style summary.
-# See test/run.c for the harness contract.
-.PHONY: check
-check: build-test
-	@./$(TESTDIR)/run -- $(TESTS)				\
-		$(TESTDIR)/t-ref-coeff_matrix.py
-
-# Slow tests: built but not part of the default check
-# target.
-.PHONY: build-test-slow
-build-test-slow: $(TESTS_SLOW)
-
-.PHONY: check-slow
-check-slow: build-test-slow $(TESTDIR)/run
-	@./$(TESTDIR)/run -- $(TESTS_SLOW)
-
-.PHONY: test-slow
-test-slow: check-slow
-
-# Sanitizer / valgrind targets.  These rebuild from scratch
-# under the requested instrumentation and re-run the full
-# test suite.
-.PHONY: test-asan test-valgrind test-mpi-asan
-ASAN_FLAGS	:= -fsanitize=address,undefined -fno-omit-frame-pointer -g
-# OpenMPI's startup path triggers internal "leaks" via
-# libevent / libopen-pal that we can't fix from here.  Disable
-# leak detection but keep all the other ASan + UBSan
-# diagnostics active.
+# --- Sanitiser / valgrind -------------------------------------------------- #
+ASAN_FLAGS       := -fsanitize=address,undefined -fno-omit-frame-pointer -g
 ASAN_OPTIONS_VAL := detect_leaks=0:halt_on_error=1
+export ASAN_OPTIONS_VAL
 
 test-asan:
 	$(MAKE) distclean
-	ASAN_OPTIONS=$(ASAN_OPTIONS_VAL)			\
-	$(MAKE) check						\
-		EXTRA_CFLAGS="$(ASAN_FLAGS)"			\
-		EXTRA_LDFLAGS="$(ASAN_FLAGS)"
+	ASAN_OPTIONS=$(ASAN_OPTIONS_VAL)				\
+	$(MAKE) check							\
+	      EXTRA_CFLAGS="$(ASAN_FLAGS)"				\
+	      EXTRA_LDFLAGS="$(ASAN_FLAGS)"
 
-test-valgrind: build-test
-	@for tt in $(TESTS); do						\
-		valgrind --quiet --error-exitcode=1			\
-			--leak-check=full				\
-			--errors-for-leak-kinds=all			\
-			--track-origins=yes ./$$tt &&			\
-			echo "$$tt: OK" ||				\
-			( echo "$$tt: FAIL"; exit 1 );			\
-	done
+test-valgrind: test-build
+	+@$(MAKE) -C $(TESTDIR) test-valgrind
 
 test-mpi-asan:
 	$(MAKE) distclean
-	$(MAKE) build-test					\
-		EXTRA_CFLAGS="$(ASAN_FLAGS)"			\
-		EXTRA_LDFLAGS="$(ASAN_FLAGS)"
-	@for tt in $(TESTDIR)/t-circ_trott_coeff; do			\
-		$(MPIRUN) -n 4 $(MPIFLAGS)				\
-			-x ASAN_OPTIONS=$(ASAN_OPTIONS_VAL) ./$$tt &&	\
-			echo "$$tt: OK" ||				\
-			( echo "$$tt: FAIL"; exit 1 );			\
-	done
+	$(MAKE) build-test						\
+	      EXTRA_CFLAGS="$(ASAN_FLAGS)"				\
+	      EXTRA_LDFLAGS="$(ASAN_FLAGS)"
+	+@$(MAKE) -C $(TESTDIR) test-mpi-asan
 
-.PHONY: check-mpi
-check-mpi: build-test
-	@./$(TESTDIR)/run --mpiranks=$(MPIRANKS) -- $(TESTS)
-
-# Pattern target: `make check-<filter>` runs the
-# subset of the suite whose effective names match
-# `<filter>*` (fnmatch glob).  The effective name is
-# the basename without the `t-` prefix and the `.py`
-# suffix.  Examples:
-#   make check-data    -> all t-data_*
-#   make check-paulis  -> just t-paulis
-#   make check-circ    -> all t-circ*
-# Explicit targets (check-mpi, check-slow,
-# check-tests-coverage) win over this pattern.
-check-%: build-test
-	@./$(TESTDIR)/run --filter='$**' -- $(TESTS)		\
-		$(TESTDIR)/t-ref-coeff_matrix.py
-
-
-# --------------------------------------------------------------------------- #
-# Clean up.                                                                   #
-# --------------------------------------------------------------------------- #
-
+# --- Clean ----------------------------------------------------------------- #
 clean:
 	@$(RM) -r $(BUILDDIR)
-	@$(RM) $(TESTDIR)/*.d
+	+@$(MAKE) -C $(TESTDIR) clean
 
 distclean: clean
-	@$(RM) $(BENCHES)
-	@$(RM) $(TESTS)
-	@$(RM) $(TESTDIR)/run
-	@$(RM) $(RUNFIX)
-	@$(RM) $(PROGS)
-	@$(RM) libphase2.so
+	+@$(MAKE) -C $(PH2RUNDIR) clean
+	+@$(MAKE) -C $(BENCHDIR) clean
+	+@$(MAKE) -C $(TESTDIR) distclean
+	@$(RM) $(TOPDIR)/libphase2.so
 
+# --- Misc ------------------------------------------------------------------ #
 format:
-	@find ./ -name "*.c" 						\
-		-or -name "*.h"						\
-		-or -name "*.cpp"					\
-		-or -name "*.cu" | 					\
-		while read f ; do					\
-			clang-format --style=file -i $$f ;		\
-		done
+	@find $(TOPDIR) -name '*.c' -o -name '*.h' -o			\
+	                -name '*.cpp' -o -name '*.cu' |			\
+		while read f; do clang-format --style=file -i "$$f"; done
 
 
-# --------------------------------------------------------------------------- #
-# Auto-dep includes.  The -MMD -MP in CFLAGS makes gcc                        #
-# emit a <obj>.d alongside every <obj>.o it produces.                         #
-# Each .d names the .o target and lists every header                          #
-# the .c #include'd, with -MP adding empty fallback                           #
-# rules for each header so a renamed header doesn't                           #
-# break the build.  The wildcard is silently empty on                         #
-# the first build.                                                            #
-# --------------------------------------------------------------------------- #
+# ========================================================================== #
+# Auto-dep includes.  -MMD -MP in CFLAGS makes gcc emit <obj>.d alongside    #
+# every <obj>.o; the .d names the .o target and lists every header the .c   #
+# #include'd transitively.  Wildcard is silently empty on first build.      #
+# ========================================================================== #
 
 -include $(shell find $(BUILDDIR) -name '*.d' 2>/dev/null)
 -include $(wildcard $(TESTDIR)/*.d)

--- a/Makefile
+++ b/Makefile
@@ -233,7 +233,8 @@ SHARED_OBJS    := $(BUILDDIR)/shared/phase2/phase2_run.o		\
                              $(PHASE2OBJS) $(LIBOBJS))
 
 shared: $(SHARED_OBJS)
-	$(CC) -shared -o $(TOPDIR)/libphase2.so $^		\
+	@$(MKDIR) $(BUILDDIR)
+	$(CC) -shared -o $(BUILDDIR)/libphase2.so $^		\
 	      $(SHARED_LDFLAGS) $(SHARED_LDLIBS)
 
 # Dispatch the -fPIC compiles into the relevant subsys's `shared` target.
@@ -262,14 +263,14 @@ check-%: test-build
 
 # --- Benchmarks ------------------------------------------------------------ #
 bench-run: bench
-	@for bb in $(BENCHDIR)/b-paulis $(BENCHDIR)/b-qreg; do		\
+	@for bb in $(BUILDDIR)/bench/b-paulis $(BUILDDIR)/bench/b-qreg; do \
 		./$$bb &&						\
 			echo "$$bb: OK" ||				\
 			( echo "$$bb: FAIL"; exit 1 );			\
 	done
 
 bench-mpi: bench
-	@for bb in $(BENCHDIR)/b-paulis $(BENCHDIR)/b-qreg; do		\
+	@for bb in $(BUILDDIR)/bench/b-paulis $(BUILDDIR)/bench/b-qreg; do \
 		$(MPIRUN) -n $(MPIRANKS) $(MPIFLAGS) ./$$bb &&		\
 			echo "$$bb: OK" ||				\
 			( echo "$$bb: FAIL"; exit 1 );			\
@@ -310,15 +311,13 @@ test-mpi-asan:
 	+@$(MAKE) -C $(TESTDIR) test-mpi-asan
 
 # --- Clean ----------------------------------------------------------------- #
+# Every compile artefact (objects, .d, binaries, libphase2.so) lives under
+# $(BUILDDIR), so `clean` is a single recursive remove.  `distclean` is an
+# alias kept for habit.
 clean:
 	@$(RM) -r $(BUILDDIR)
-	+@$(MAKE) -C $(TESTDIR) clean
 
 distclean: clean
-	+@$(MAKE) -C $(PH2RUNDIR) clean
-	+@$(MAKE) -C $(BENCHDIR) clean
-	+@$(MAKE) -C $(TESTDIR) distclean
-	@$(RM) $(TOPDIR)/libphase2.so
 
 # --- Misc ------------------------------------------------------------------ #
 format:

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ VERSION_PATCH	:= 0
 AS		:= nasm
 ASFLAGS		+= -felf64 -w+all -w-reloc-rel-dword -Ox
 CC		?= gcc
-CFLAGS		+= -std=c11 -Wall -Wextra -O3 -march=native -mavx2
+CFLAGS		+= -std=c11 -Wall -Wextra -O3 -march=native -mavx2 -MMD -MP
 # EXTRA_CFLAGS / EXTRA_LDFLAGS allow command-line overrides
 # (e.g. for sanitizer builds) without clobbering the rest of
 # the build flag pipeline.
@@ -99,9 +99,6 @@ BACKEND_CFLAGS	+= -I$(CUDA_INCLUDE)
 BACKEND_LDFLAGS	+= -L$(CUDA_LIBDIR) -Wl,-rpath -Wl,$(CUDA_LIBDIR)
 BACKEND_LDLIBS	+= -lcudart -lstdc++
 
-$(BACKEND_OBJS): $(PHASE2DIR)/qreg_cuda.h				\
-       			$(PHASE2DIR)/world_cuda.h
-
 NVCCFLAGS	+= $(MPI_CFLAGS) $(HDF5_CFLAGS)
 $(PHASE2DIR)/qreg_cuda_lo.o: $(PHASE2DIR)/qreg_cuda_lo.cu
 	$(NVCC) $(NVCCFLAGS) $(BACKEND_CFLAGS) 				\
@@ -112,31 +109,15 @@ $(PHASE2DIR)/qreg_cuda_lo_dlink.o: $(PHASE2DIR)/qreg_cuda_lo.o
 
 endif
 
-$(BACKEND_OBJS): $(PHASE2DIR)/qreg.h
-
 BACKEND_CFLAGS	+= -DPHASE2_BACKEND=$(BACKEND_N)
 
 
-# phase2 public API
-$(PHASE2DIR)/circ.o:	$(INCLUDE)/phase2/circ.h			\
-			$(INCLUDE)/phase2/state_prep_coeff.h
-$(PH2RUNDIR)/data.o:	$(INCLUDE)/phase2/circ.h $(INCLUDE)/ph2run/data.h	\
-			$(INCLUDE)/phase2/paulis.h
-$(PHASE2DIR)/paulis.o:	$(INCLUDE)/phase2/paulis.h
-$(PHASE2DIR)/prob.o:	$(INCLUDE)/phase2/prob.h
-$(PHASE2DIR)/qreg.o:	$(INCLUDE)/phase2/qreg.h $(PHASE2DIR)/qreg.h
-$(PHASE2DIR)/state_prep_coeff.o:	$(INCLUDE)/phase2/state_prep_coeff.h	\
-			$(INCLUDE)/combinations.h			\
-			$(INCLUDE)/det_small.h				\
-			$(INCLUDE)/phase2/circ.h			\
-			$(INCLUDE)/phase2/qreg.h			\
-			$(PHASE2DIR)/qreg.h
-$(PHASE2DIR)/world.o:	$(INCLUDE)/phase2/world.h
-
-# internal API
-$(PHASE2DIR)/circ_cache.o:	$(PHASE2DIR)/circ_cache.h
-$(PHASE2DIR)/phase2_run.o:	$(INCLUDE)/phase2/phase2_run.h		\
-				$(PHASE2DIR)/circ_cache.h
+# Header dependencies for every compiled .c are tracked
+# automatically via -MMD/-MP (see CFLAGS below); the
+# emitted .d files are pulled in at the foot of this
+# file.  The Makefile only declares structural deps:
+# object-set unions, inter-target link prereqs, and
+# generated-header prereqs (none today).
 
 PHASE2OBJS	:= $(PHASE2DIR)/circ.o					\
 			$(PHASE2DIR)/circ_cache.o			\
@@ -147,28 +128,12 @@ PHASE2OBJS	:= $(PHASE2DIR)/circ.o					\
 			$(PHASE2DIR)/world.o				\
 			$(BACKEND_OBJS)
 
-$(PHASE2OBJS):	$(INCLUDE)/phase2.h
-
 PH2RUN_DATA_OBJS := $(PH2RUNDIR)/data.o
-
-
-# Circuits
-$(CIRCDIR)/cmpsit.o: $(INCLUDE)/circ/cmpsit.h
-$(CIRCDIR)/qdrift.o: $(INCLUDE)/circ/qdrift.h
-$(CIRCDIR)/trott.o: $(INCLUDE)/circ/trott.h
-$(CIRCDIR)/trott2.o: $(INCLUDE)/circ/trott2.h
 
 CIRCOBJS	:= $(CIRCDIR)/cmpsit.o					\
 			$(CIRCDIR)/qdrift.o				\
 			$(CIRCDIR)/trott.o				\
 			$(CIRCDIR)/trott2.o
-
-
-# Library / utilities
-$(LIBDIR)/combinations.o: $(INCLUDE)/combinations.h
-$(LIBDIR)/det_small.o:	$(INCLUDE)/det_small.h
-$(LIBDIR)/log.o:	$(INCLUDE)/log.h
-$(LIBDIR)/xoshiro256ss.o: $(INCLUDE)/xoshiro256ss.h
 
 LIBOBJS		:= $(LIBDIR)/combinations.o				\
 			$(LIBDIR)/det_small.o				\
@@ -486,3 +451,20 @@ format:
 			clang-format --style=file -i $$f ;		\
 		done
 
+
+# --------------------------------------------------------------------------- #
+# Auto-dep includes.  The -MMD -MP in CFLAGS makes gcc                        #
+# emit a <obj>.d alongside every <obj>.o it produces.                         #
+# Each .d names the .o target and lists every header                          #
+# the .c #include'd, with -MP adding empty fallback                           #
+# rules for each header so a renamed header doesn't                           #
+# break the build.  The wildcard is silently empty on                         #
+# the first build.                                                            #
+# --------------------------------------------------------------------------- #
+
+-include $(wildcard $(CIRCDIR)/*.d		\
+		$(BENCHDIR)/*.d			\
+		$(LIBDIR)/*.d			\
+		$(PH2RUNDIR)/*.d		\
+		$(PHASE2DIR)/*.d		\
+		$(TESTDIR)/*.d)

--- a/Makefile
+++ b/Makefile
@@ -147,6 +147,23 @@ LIBOBJS		:= $(BUILDDIR)/lib/combinations.o			\
 			$(BUILDDIR)/lib/log.o				\
 			$(BUILDDIR)/lib/xoshiro256ss.o
 
+# Manifest of every .c / .cu source that the build
+# system knows how to compile.  Used by the
+# `check-srcs-coverage` drift guard to fail the
+# build when a new source file is added to a
+# subsystem directory but not wired into an OBJS
+# variable.
+DECLARED_SRCS	:= $(patsubst $(BUILDDIR)/%.o,%.c,			\
+			$(PHASE2OBJS) $(CIRCOBJS)			\
+			$(LIBOBJS) $(PH2RUN_DATA_OBJS))			\
+		   phase2/phase2_run.c					\
+		   ph2run/ph2run.c					\
+		   bench/bench.c					\
+		   bench/b-paulis.c bench/b-qreg.c			\
+		   phase2/qreg_cuda.c					\
+		   phase2/qreg_cuda_lo.cu				\
+		   phase2/world_cuda.c
+
 # Generic compile rules.  Two variants:
 #  - $(BUILDDIR)/%.o:  regular objects.
 #  - $(BUILDDIR)/shared/%.o:  same sources rebuilt
@@ -210,7 +227,7 @@ debug: build build-bench build-test
 debug: ASFLAGS	+= -DDEBUG -Og -Fdwarf
 debug: CFLAGS	+= -DDEBUG -g -Og
 
-build: $(PROGS)
+build: check-srcs-coverage $(PROGS)
 
 # --------------------------------------------------------------------------- #
 # Shared library (Python interface)                                           #
@@ -351,6 +368,30 @@ check-tests-coverage:
 	rc=0;							\
 	if [ -n "$$missing" ]; then				\
 		echo "test/: t-*.c files not in TESTS:";	\
+		echo "$$missing";				\
+		rc=1;						\
+	fi;							\
+	rm -rf $$tmp;						\
+	exit $$rc
+
+# Drift guard for the subsystem source dirs (phase2,
+# circ, lib, ph2run, bench).  Enumerate every .c /
+# .cu in those directories and verify each appears
+# in DECLARED_SRCS.  A new source dropped into one
+# of them but not wired into an OBJS variable fails
+# the build immediately.
+.PHONY: check-srcs-coverage
+check-srcs-coverage:
+	@tmp=$$(mktemp -d);					\
+	ls phase2/*.c phase2/*.cu				\
+	   circ/*.c lib/*.c ph2run/*.c bench/*.c		\
+	   2>/dev/null | sort > $$tmp/expected;			\
+	for s in $(DECLARED_SRCS); do echo $$s; done		\
+		| sort -u > $$tmp/declared;			\
+	missing=$$(comm -23 $$tmp/expected $$tmp/declared);	\
+	rc=0;							\
+	if [ -n "$$missing" ]; then				\
+		echo "build: .c sources not in DECLARED_SRCS:";	\
 		echo "$$missing";				\
 		rc=1;						\
 	fi;							\

--- a/README.md
+++ b/README.md
@@ -46,14 +46,14 @@ Simulate four 1st-order Trotter steps on the water
 CAS(5,6) test fixture, on two MPI ranks:
 
 ```bash
-mpirun -n 2 ./ph2run/ph2run -S test/data/H2O_CAS56.h5 \
+mpirun -n 2 ./build/ph2run/ph2run -S test/data/H2O_CAS56.h5 \
        trott -D 0.1 -s 4
 ```
 
 Results land in the `/circ_trott` group of the same HDF5
 file.  Other subcommands — `trott2`, `qdrift`, `cmpsit` —
 share the same `-S FILE` convention; see
-`./ph2run/ph2run --help` and `./ph2run/ph2run CMD --help`
+`./build/ph2run/ph2run --help` and `./build/ph2run/ph2run CMD --help`
 for the flag surface.
 
 The MPI rank count must be a power of two and must not

--- a/bench/Makefile
+++ b/bench/Makefile
@@ -1,0 +1,51 @@
+# ========================================================================== #
+# bench -- micro-benchmarks (b-paulis, b-qreg)                               #
+#                                                                            #
+# Compiles bench/bench.c into $(BUILDDIR)/bench/bench.o (a shared support    #
+# unit used by every b-*) and links the benchmark binaries from b-*.c plus  #
+# the prebuilt subsys objects.                                              #
+# ========================================================================== #
+
+ifndef TOPDIR
+$(error TOPDIR not set -- invoke via top-level Makefile, e.g. `make -C ..`)
+endif
+
+SUBSYS := bench
+include $(TOPDIR)/build-rules.mk
+
+# Per-benchmark source files; each builds to a binary
+# at $(BENCHDIR)/<name>.
+PROGS := b-paulis b-qreg
+
+# Shared support code linked into every benchmark.
+SHARED_SRCS := bench.c
+SHARED_OBJS := $(SHARED_SRCS:%.c=$(BUILDDIR)/bench/%.o)
+
+# bench's headers live alongside its sources; tell gcc.
+CFLAGS += -I.
+
+.PHONY: all check-srcs-coverage clean
+all: $(PROGS)
+
+# Per-binary link rule.  b-NAME built from b-NAME.c +
+# bench.o + every upstream subsys object set.
+$(PROGS): %: %.c bench.h $(SHARED_OBJS) \
+              $(PHASE2OBJS) $(LIBOBJS) $(PH2RUN_DATA_OBJS)
+	$(CC) $(CFLAGS) $(LDFLAGS) $< $(SHARED_OBJS) \
+	      $(PHASE2OBJS) $(LIBOBJS) $(PH2RUN_DATA_OBJS) \
+	      $(LDLIBS) -o $@
+
+check-srcs-coverage:
+	@declared=" $(SHARED_SRCS) $(PROGS:%=%.c) ";			\
+	rc=0;								\
+	for s in *.c; do						\
+		[ -f "$$s" ] || continue;				\
+		case "$$declared" in *" $$s "*) ;;			\
+		*) echo "bench: $$s missing from SRCS"; rc=1 ;;		\
+		esac;							\
+	done;								\
+	exit $$rc
+
+clean:
+	@$(RM) -r $(BUILDDIR)/bench
+	@$(RM) $(PROGS)

--- a/bench/Makefile
+++ b/bench/Makefile
@@ -14,8 +14,9 @@ SUBSYS := bench
 include $(TOPDIR)/build-rules.mk
 
 # Per-benchmark source files; each builds to a binary
-# at $(BENCHDIR)/<name>.
-PROGS := b-paulis b-qreg
+# at $(BUILDDIR)/bench/<name>.
+PROG_NAMES := b-paulis b-qreg
+PROGS      := $(PROG_NAMES:%=$(BUILDDIR)/bench/%)
 
 # Shared support code linked into every benchmark.
 SHARED_SRCS := bench.c
@@ -27,16 +28,18 @@ CFLAGS += -I.
 .PHONY: all check-srcs-coverage clean
 all: $(PROGS)
 
-# Per-binary link rule.  b-NAME built from b-NAME.c +
-# bench.o + every upstream subsys object set.
-$(PROGS): %: %.c bench.h $(SHARED_OBJS) \
-              $(PHASE2OBJS) $(LIBOBJS) $(PH2RUN_DATA_OBJS)
-	$(CC) $(CFLAGS) $(LDFLAGS) $< $(SHARED_OBJS) \
-	      $(PHASE2OBJS) $(LIBOBJS) $(PH2RUN_DATA_OBJS) \
+# Per-binary link rule.  $(BUILDDIR)/bench/b-NAME built
+# from b-NAME.c + bench.o + every upstream subsys
+# object set.
+$(PROGS): $(BUILDDIR)/bench/%: %.c bench.h $(SHARED_OBJS)	\
+                               $(PHASE2OBJS) $(LIBOBJS) $(PH2RUN_DATA_OBJS)
+	@$(MKDIR) $(@D)
+	$(CC) $(CFLAGS) $(LDFLAGS) $< $(SHARED_OBJS)		\
+	      $(PHASE2OBJS) $(LIBOBJS) $(PH2RUN_DATA_OBJS)	\
 	      $(LDLIBS) -o $@
 
 check-srcs-coverage:
-	@declared=" $(SHARED_SRCS) $(PROGS:%=%.c) ";			\
+	@declared=" $(SHARED_SRCS) $(PROG_NAMES:%=%.c) ";		\
 	rc=0;								\
 	for s in *.c; do						\
 		[ -f "$$s" ] || continue;				\
@@ -46,6 +49,7 @@ check-srcs-coverage:
 	done;								\
 	exit $$rc
 
+# Bench binaries live under $(BUILDDIR)/bench/; top-level
+# `make clean` wipes $(BUILDDIR) wholesale.
 clean:
-	@$(RM) -r $(BUILDDIR)/bench
-	@$(RM) $(PROGS)
+	@:

--- a/build-rules.mk
+++ b/build-rules.mk
@@ -1,0 +1,18 @@
+# ========================================================================== #
+# build-rules.mk -- shared compile rules for the phase2 build                #
+#                                                                            #
+# Included by every per-subsystem Makefile after that Makefile sets SUBSYS   #
+# to its own directory name.  Two pattern rules emit objects under           #
+# $(BUILDDIR)/<subsys>/ (regular) and $(BUILDDIR)/shared/<subsys>/ (-fPIC,   #
+# for the shared library).  Header deps are auto-tracked via gcc -MMD -MP    #
+# (set in CFLAGS at the top level); the .d files are pulled in at the foot  #
+# of the top-level Makefile.                                                 #
+# ========================================================================== #
+
+$(BUILDDIR)/$(SUBSYS)/%.o: %.c
+	@$(MKDIR) $(@D)
+	$(CC) $(CFLAGS) -c $< -o $@
+
+$(BUILDDIR)/shared/$(SUBSYS)/%.o: %.c
+	@$(MKDIR) $(@D)
+	$(CC) $(CFLAGS) -fPIC -c $< -o $@

--- a/circ/Makefile
+++ b/circ/Makefile
@@ -1,0 +1,32 @@
+# ========================================================================== #
+# circ -- Trotter / Strang-Trotter / qDRIFT / composite circuit algorithms   #
+# ========================================================================== #
+
+ifndef TOPDIR
+$(error TOPDIR not set -- invoke via top-level Makefile, e.g. `make -C ..`)
+endif
+
+SUBSYS := circ
+include $(TOPDIR)/build-rules.mk
+
+SRCS  := cmpsit.c qdrift.c trott.c trott2.c
+OBJS  := $(SRCS:%.c=$(BUILDDIR)/circ/%.o)
+SOBJS := $(SRCS:%.c=$(BUILDDIR)/shared/circ/%.o)
+
+.PHONY: all shared check-srcs-coverage clean
+all:    $(OBJS)
+shared: $(SOBJS)
+
+check-srcs-coverage:
+	@declared=" $(SRCS) ";						\
+	rc=0;								\
+	for s in *.c; do						\
+		[ -f "$$s" ] || continue;				\
+		case "$$declared" in *" $$s "*) ;;			\
+		*) echo "circ: $$s missing from SRCS"; rc=1 ;;		\
+		esac;							\
+	done;								\
+	exit $$rc
+
+clean:
+	@$(RM) -r $(BUILDDIR)/circ $(BUILDDIR)/shared/circ

--- a/doc/logging.md
+++ b/doc/logging.md
@@ -204,7 +204,7 @@ Quick recipe when editing a file that does not yet emit:
 **Small run (info, default).**
 
 ```sh
-./ph2run/ph2run -S test/data/H2O_CAS56.h5 trott -D 0.1 -s 4
+./build/ph2run/ph2run -S test/data/H2O_CAS56.h5 trott -D 0.1 -s 4
 ```
 
 ```
@@ -226,7 +226,7 @@ Quick recipe when editing a file that does not yet emit:
 
 ```sh
 make debug
-PHASE2_LOG=debug ./ph2run/ph2run -S test/data/H2O_CAS56.h5 trott -s 4
+PHASE2_LOG=debug ./build/ph2run/ph2run -S test/data/H2O_CAS56.h5 trott -s 4
 ```
 
 Adds engine-layer DEBUG lines: `data_open`, qubit layout,
@@ -236,7 +236,7 @@ hamil sort, per-step debug markers, cache flush counts.
 
 ```sh
 mpirun -n 4 -x PHASE2_LOG_ALL=1 -x PHASE2_LOG=info \
-    ./ph2run/ph2run -S test/data/H2O_CAS56.h5 trott -s 4
+    ./build/ph2run/ph2run -S test/data/H2O_CAS56.h5 trott -s 4
 ```
 
 Rank-0 lines remain unprefixed; ranks 1-3 prefix every

--- a/doc/phase2.md
+++ b/doc/phase2.md
@@ -1545,11 +1545,12 @@ happens during data loading in `circ_hamil_load`.
 | `check-slow`           | Run TESTS_SLOW (excluded from default `check`) |
 | `check-<filter>`       | Run the subset matching `<filter>*` (`check-data`) |
 | `check-tests-coverage` | Guard: every `test/t-*.c` is in TESTS / TESTS_SLOW |
+| `check-srcs-coverage`  | Guard: every subsys-dir source is in DECLARED_SRCS |
 | `bench`                | Run benchmarks (single rank)          |
 | `bench-mpi`            | Run benchmarks under MPI              |
 | `debug`                | Build with debug flags (-g -Og)       |
-| `clean`                | Remove object files                   |
-| `distclean`            | Remove object files, binaries, tests  |
+| `clean`                | Remove the `build/` tree              |
+| `distclean`            | Also remove binaries and `libphase2.so` |
 | `format`               | Run clang-format on all sources       |
 
 ### 10.2 Backend Selection
@@ -1608,3 +1609,49 @@ See [doc/testing.md](testing.md) for the full subsystem
 reference: macro contract, fixture pattern, runner flags,
 recipes for adding tests, sanitiser / valgrind targets.
 Test data files reside in `test/data/`.
+
+### 10.5 Build Organisation
+
+The Makefile is a single top-level driver.  Every
+compiled object and header-dep file lands under
+`build/<srcdir>/`, mirroring the source tree:
+
+    phase2/circ.c  ->  build/phase2/circ.o + build/phase2/circ.d
+    lib/log.c      ->  build/lib/log.o     + build/lib/log.d
+    ...
+
+Final binaries stay next to their sources
+(`ph2run/ph2run`, `test/t-paulis`, `bench/b-paulis`,
+`test/run`, `libphase2.so` at the repo root).  Only
+intermediate `.o` and `.d` move under `build/`.
+
+Header dependencies are tracked automatically via
+`gcc -MMD -MP`: every compile emits a
+`build/<dir>/<x>.d` describing which headers the
+`.c` `#include`'d transitively, with empty fallback
+rules for each header so a renamed header doesn't
+break the build.  The Makefile `-include`s the dep
+files at the foot of the file; the wildcard is
+silently empty on first build.  The result is that
+touching a header reliably rebuilds every dependent
+object -- there are no hand-declared per-object
+header prereqs to keep in sync.
+
+The shared library (`libphase2.so`) compiles the
+same sources with `-fPIC` into a disjoint tree at
+`build/shared/<srcdir>/`.  Running `make build` and
+`make shared` (in either order) cannot mix PIC and
+non-PIC objects, because the two layouts live on
+different paths.
+
+The `check-srcs-coverage` rule (a prerequisite of
+`build`) is a drift guard: it enumerates every
+`.c` and `.cu` under `phase2/`, `circ/`, `lib/`,
+`ph2run/`, `bench/` and fails the build if any of
+them is missing from the `DECLARED_SRCS` manifest.
+Mirrors `check-tests-coverage` on the test side.
+
+`make clean` collapses to `rm -rf build/` plus the
+`test/*.d` stragglers from the test binaries' own
+`-MMD` output.  `make distclean` additionally
+removes the binaries and `libphase2.so`.

--- a/doc/phase2.md
+++ b/doc/phase2.md
@@ -1640,16 +1640,20 @@ values visible to sub-makes.  Section 3 is
 phase2`, ...) and the user-visible high-level
 targets.
 
-Every compiled `.o` and `.d` lands under
+Every compile artefact -- objects, header-dep files,
+final binaries, the shared library -- lands under
 `$(BUILDDIR)/<srcdir>/`, mirroring the source tree:
 
-    phase2/circ.c  ->  build/phase2/circ.o + build/phase2/circ.d
-    lib/log.c      ->  build/lib/log.o     + build/lib/log.d
+    phase2/circ.c    ->  build/phase2/circ.o + build/phase2/circ.d
+    lib/log.c        ->  build/lib/log.o     + build/lib/log.d
+    ph2run/ph2run.c  ->  build/ph2run/ph2run (binary)
+    test/t-paulis.c  ->  build/test/t-paulis (binary)
+    bench/b-paulis.c ->  build/bench/b-paulis (binary)
+    test/run.c       ->  build/test/run (binary)
+    (shared lib)     ->  build/libphase2.so
 
-Final binaries stay next to their sources
-(`ph2run/ph2run`, `test/t-paulis`, `bench/b-paulis`,
-`test/run`, `libphase2.so` at the repo root).  Only
-intermediate `.o` and `.d` move under `build/`.
+Source directories stay clean -- no `.o`, no
+binaries.  `make clean` is a single `rm -rf build/`.
 
 Header dependencies are tracked automatically via
 `gcc -MMD -MP`: every compile emits a

--- a/doc/phase2.md
+++ b/doc/phase2.md
@@ -1612,13 +1612,39 @@ Test data files reside in `test/data/`.
 
 ### 10.5 Build Organisation
 
-The Makefile is a single top-level driver.  Every
-compiled object and header-dep file lands under
-`build/<srcdir>/`, mirroring the source tree:
+The build is split into a top-level orchestrator
+plus a per-subsystem Makefile in each source dir:
+
+    Makefile                <- orchestrator + config
+    build-rules.mk          <- shared compile rules
+    phase2/Makefile         <- compiles phase2 sources
+    circ/Makefile
+    lib/Makefile
+    ph2run/Makefile         <- + links ph2run
+    bench/Makefile          <- + links b-paulis, b-qreg
+    test/Makefile           <- + tests, runner, fixtures
+
+The top-level Makefile reads in three sections.
+Section 1 is **USER CONFIGURATION**: toolchain
+(`CC`, `CFLAGS`, `EXTRA_CFLAGS`), MPI library paths
+(`MPI_CFLAGS`, `MPI_LDFLAGS`, `MPI_LDLIBS`), HDF5
+paths (`HDF5_CFLAGS`, `HDF5_LDFLAGS`,
+`HDF5_LDLIBS`), backend selection (`BACKEND`,
+`CUDA_PREFIX`, `NVCCFLAGS`), `BUILDDIR`, and
+`VERSION`.  A user porting phase2 to a new machine
+edits this block only.  Section 2 is **INTERNAL**:
+subsystem layout, derived OBJS unions, the CFLAGS
+pipeline, the `export` contract that makes Section 1
+values visible to sub-makes.  Section 3 is
+**TARGETS**: per-subsys dispatch (`$(MAKE) -C
+phase2`, ...) and the user-visible high-level
+targets.
+
+Every compiled `.o` and `.d` lands under
+`$(BUILDDIR)/<srcdir>/`, mirroring the source tree:
 
     phase2/circ.c  ->  build/phase2/circ.o + build/phase2/circ.d
     lib/log.c      ->  build/lib/log.o     + build/lib/log.d
-    ...
 
 Final binaries stay next to their sources
 (`ph2run/ph2run`, `test/t-paulis`, `bench/b-paulis`,
@@ -1630,12 +1656,12 @@ Header dependencies are tracked automatically via
 `build/<dir>/<x>.d` describing which headers the
 `.c` `#include`'d transitively, with empty fallback
 rules for each header so a renamed header doesn't
-break the build.  The Makefile `-include`s the dep
-files at the foot of the file; the wildcard is
-silently empty on first build.  The result is that
-touching a header reliably rebuilds every dependent
-object -- there are no hand-declared per-object
-header prereqs to keep in sync.
+break the build.  The top-level Makefile
+`-include`s the dep files at its foot; the wildcard
+is silently empty on first build.  Touching a
+header reliably rebuilds every dependent object --
+there are no hand-declared per-object header
+prereqs to keep in sync.
 
 The shared library (`libphase2.so`) compiles the
 same sources with `-fPIC` into a disjoint tree at
@@ -1644,14 +1670,35 @@ same sources with `-fPIC` into a disjoint tree at
 non-PIC objects, because the two layouts live on
 different paths.
 
-The `check-srcs-coverage` rule (a prerequisite of
-`build`) is a drift guard: it enumerates every
-`.c` and `.cu` under `phase2/`, `circ/`, `lib/`,
-`ph2run/`, `bench/` and fails the build if any of
-them is missing from the `DECLARED_SRCS` manifest.
-Mirrors `check-tests-coverage` on the test side.
+Each subsys Makefile carries its own
+`check-srcs-coverage` rule: it enumerates `*.c` (and
+`*.cu` for phase2) in its own dir and fails the
+build if any source isn't listed in the subsys's
+`SRCS`.  The top-level `check-srcs-coverage` is a
+prerequisite of `build` and dispatches each subsys's
+check.  `test/Makefile` carries the analogous
+`check-tests-coverage` drift guard for the TESTS
+manifest.
 
-`make clean` collapses to `rm -rf build/` plus the
-`test/*.d` stragglers from the test binaries' own
-`-MMD` output.  `make distclean` additionally
-removes the binaries and `libphase2.so`.
+#### Adding a new subsystem
+
+1. Create `<subsys>/Makefile` modelled on
+   `lib/Makefile` (the simplest existing one).  Set
+   `SUBSYS := <subsys>`, list `SRCS`, derive
+   `OBJS`, define `all` / `shared` /
+   `check-srcs-coverage` / `clean`.
+2. In the top-level Makefile's Section 2, add
+   `<SUBSYS>OBJS` to the union block.
+3. In Section 3, add a phony dispatch target
+   `<subsys>:` that invokes `$(MAKE) -C <subsys>`,
+   plus the appropriate dep edges to upstream
+   subsystems.
+4. If the new subsys links a binary, add its build
+   rule to that subsys's Makefile (model on
+   `ph2run/Makefile`).
+
+`make clean` removes `$(BUILDDIR)/`.  `make
+distclean` additionally removes the built binaries
+and `libphase2.so`.  Sub-makes refuse to run
+standalone -- they error with a pointer to the
+top-level Makefile.

--- a/doc/python.md
+++ b/doc/python.md
@@ -33,7 +33,7 @@ layer.
 make shared
 ```
 
-This produces `libphase2.so` in the project root.  The build
+This produces `libphase2.so` under `build/`.  The build
 requires GCC, OpenMPI, and parallel HDF5 development headers.
 
 ### 2. Create and activate a virtual environment
@@ -90,9 +90,11 @@ pytest -v
 The module locates `libphase2.so` by searching, in order:
 
 1. The path in the `PHASE2_LIB` environment variable.
-2. `../../libphase2.so` relative to the installed package.
-3. `../libphase2.so` relative to the installed package.
-4. `./libphase2.so` relative to the installed package.
+2. `../../build/libphase2.so` relative to the installed
+   package -- the in-tree development build's output.
+3. `../../libphase2.so` relative to the installed package.
+4. `../libphase2.so` relative to the installed package.
+5. `./libphase2.so` relative to the installed package.
 
 To override the search, set `PHASE2_LIB` explicitly:
 

--- a/doc/testing.md
+++ b/doc/testing.md
@@ -45,24 +45,34 @@ make test-mpi-asan
 
 ## 2. Layout
 
+Sources live under `test/`; compiled binaries land
+under `build/test/` (mirrors the source tree, kept
+out of git).
+
 ```
-test/
+test/                  (sources)
   test.h               -- macro core (TEST_FAIL, TEST_ASSERT, ...)
   t-<subsys>[_<aspect>].c   -- one binary per logical unit
   t-data.h             -- per-subsystem fixture helpers (model)
   t-ref-coeff_matrix.py     -- Python cross-validator
-  run.c                -- the parallel runner (built to test/run)
+  run.c                -- the parallel runner
   t-run.c              -- self-tests for the runner
-  run-fixtures/        -- synthetic fixtures driven by t-run
+  run-fixtures/*.c     -- synthetic fixtures driven by t-run
   data/                -- on-disk HDF5 fixtures for the C tests
   ref/                 -- in-tree Python reference oracles
+
+build/test/            (binaries -- emitted by the build)
+  t-<subsys>[_<aspect>]      -- test binary
+  run                  -- parallel runner
+  run-fixtures/{pass,fail,sleep,abort,banner}   -- t-run fixtures
 ```
 
 C binaries follow the prefix convention
 `t-<subsys>[_<aspect>].c`.  Examples:
 `t-paulis.c`, `t-data_hamil.c`, `t-circ_trott_coeff.c`.
-The matching binary lands under the same name and is
-listed in the Makefile's `TESTS` variable.
+The matching binary lands at
+`build/test/<same-name>` and is listed in the
+Makefile's `TESTS` variable.
 
 The slow test (`t-state_prep_coeff_large`) is declared
 in `TESTS_SLOW` and is excluded from default `check`.
@@ -144,14 +154,15 @@ intentional; the kernel reaps it.
 
 ## 5. The runner
 
-`test/run` is a standalone single-file C program
-(libc + POSIX only, no phase2 / MPI / HDF5 deps).
-It takes a list of test paths and runs them in
-parallel, capturing per-test output, and prints a
-cargo-style summary.
+The runner source is `test/run.c`; the build emits
+the binary at `build/test/run`.  Standalone
+single-file C program (libc + POSIX only, no
+phase2 / MPI / HDF5 deps).  It takes a list of
+test paths and runs them in parallel, capturing
+per-test output, and prints a cargo-style summary.
 
 ```
-./test/run [OPTIONS] -- TEST...
+./build/test/run [OPTIONS] -- TEST...
 ```
 
 | Flag             | Default      | Effect                              |
@@ -165,7 +176,7 @@ cargo-style summary.
 
 The *effective name* is the basename of the test path
 with the leading `t-` and any `.py` suffix stripped:
-`./test/t-data_mpi -> "data_mpi"`,
+`./build/test/t-data_mpi -> "data_mpi"`,
 `./test/t-ref-coeff_matrix.py -> "ref-coeff_matrix"`.
 Filter examples: `--filter='data*'`,
 `--filter='*coeff*'`, `--filter='paulis'`.

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -1,0 +1,32 @@
+# ========================================================================== #
+# lib -- utilities (combinations, det_small, log, xoshiro256ss)              #
+# ========================================================================== #
+
+ifndef TOPDIR
+$(error TOPDIR not set -- invoke via top-level Makefile, e.g. `make -C ..`)
+endif
+
+SUBSYS := lib
+include $(TOPDIR)/build-rules.mk
+
+SRCS  := combinations.c det_small.c log.c xoshiro256ss.c
+OBJS  := $(SRCS:%.c=$(BUILDDIR)/lib/%.o)
+SOBJS := $(SRCS:%.c=$(BUILDDIR)/shared/lib/%.o)
+
+.PHONY: all shared check-srcs-coverage clean
+all:    $(OBJS)
+shared: $(SOBJS)
+
+check-srcs-coverage:
+	@declared=" $(SRCS) ";						\
+	rc=0;								\
+	for s in *.c; do						\
+		[ -f "$$s" ] || continue;				\
+		case "$$declared" in *" $$s "*) ;;			\
+		*) echo "lib: $$s missing from SRCS"; rc=1 ;;		\
+		esac;							\
+	done;								\
+	exit $$rc
+
+clean:
+	@$(RM) -r $(BUILDDIR)/lib $(BUILDDIR)/shared/lib

--- a/ph2run/Makefile
+++ b/ph2run/Makefile
@@ -22,7 +22,7 @@ SOBJS :=
 
 # Program source (linked into the ph2run binary).
 PROG_SRC := ph2run.c
-PROG_BIN := ph2run
+PROG_BIN := $(BUILDDIR)/ph2run/ph2run
 
 .PHONY: all data check-srcs-coverage clean
 all:  $(PROG_BIN)
@@ -33,6 +33,7 @@ data: $(OBJS)
 # the env (PHASE2OBJS, CIRCOBJS, LIBOBJS) exported by
 # the top-level Makefile.
 $(PROG_BIN): $(PROG_SRC) $(OBJS) $(PHASE2OBJS) $(CIRCOBJS) $(LIBOBJS)
+	@$(MKDIR) $(@D)
 	$(CC) $(CFLAGS) $(LDFLAGS) $^ $(LDLIBS) -o $@
 
 check-srcs-coverage:
@@ -46,6 +47,7 @@ check-srcs-coverage:
 	done;								\
 	exit $$rc
 
+# ph2run binary lives under $(BUILDDIR)/ph2run/; top-level
+# `make clean` wipes $(BUILDDIR) wholesale.
 clean:
-	@$(RM) -r $(BUILDDIR)/ph2run
-	@$(RM) $(PROG_BIN)
+	@:

--- a/ph2run/Makefile
+++ b/ph2run/Makefile
@@ -1,0 +1,51 @@
+# ========================================================================== #
+# ph2run -- driver CLI (ph2run binary) and the HDF5 data loader              #
+#                                                                            #
+# Compiles ph2run/data.c into $(BUILDDIR)/ph2run/data.o and links the        #
+# ph2run binary from ph2run.c + the prebuilt phase2 / circ / lib /           #
+# ph2run-data objects.  The top-level Makefile ensures the upstream subsys  #
+# objects exist before invoking this sub-make.                              #
+# ========================================================================== #
+
+ifndef TOPDIR
+$(error TOPDIR not set -- invoke via top-level Makefile, e.g. `make -C ..`)
+endif
+
+SUBSYS := ph2run
+include $(TOPDIR)/build-rules.mk
+
+# Source of the data loader (compiled to an .o reused
+# by tests and benches).
+SRCS  := data.c
+OBJS  := $(SRCS:%.c=$(BUILDDIR)/ph2run/%.o)
+SOBJS :=
+
+# Program source (linked into the ph2run binary).
+PROG_SRC := ph2run.c
+PROG_BIN := ph2run
+
+.PHONY: all data check-srcs-coverage clean
+all:  $(PROG_BIN)
+data: $(OBJS)
+
+# Link ph2run: ph2run.c plus the data.o + every upstream
+# subsys object.  Inter-subsys link prereqs come from
+# the env (PHASE2OBJS, CIRCOBJS, LIBOBJS) exported by
+# the top-level Makefile.
+$(PROG_BIN): $(PROG_SRC) $(OBJS) $(PHASE2OBJS) $(CIRCOBJS) $(LIBOBJS)
+	$(CC) $(CFLAGS) $(LDFLAGS) $^ $(LDLIBS) -o $@
+
+check-srcs-coverage:
+	@declared=" $(SRCS) $(PROG_SRC) ";				\
+	rc=0;								\
+	for s in *.c; do						\
+		[ -f "$$s" ] || continue;				\
+		case "$$declared" in *" $$s "*) ;;			\
+		*) echo "ph2run: $$s missing from SRCS"; rc=1 ;;	\
+		esac;							\
+	done;								\
+	exit $$rc
+
+clean:
+	@$(RM) -r $(BUILDDIR)/ph2run
+	@$(RM) $(PROG_BIN)

--- a/phase2/Makefile
+++ b/phase2/Makefile
@@ -1,0 +1,65 @@
+# ========================================================================== #
+# phase2 -- state-vector kernel, Pauli arithmetic, register layout, world    #
+#                                                                            #
+# Compiles phase2/*.c into $(BUILDDIR)/phase2/*.o.  Backend-conditional      #
+# sources (qreg_qreg.c for CPU, qreg_cuda*.c + world_cuda.c for GPU) are     #
+# pulled in via $(BACKEND_OBJS) exported by the top-level Makefile.  The     #
+# CUDA NVCC rule for qreg_cuda_lo.cu lives here too.                         #
+# ========================================================================== #
+
+ifndef TOPDIR
+$(error TOPDIR not set -- invoke via top-level Makefile, e.g. `make -C ..`)
+endif
+
+SUBSYS := phase2
+include $(TOPDIR)/build-rules.mk
+
+# Always-compiled sources.
+SRCS  := circ.c circ_cache.c paulis.c prob.c qreg.c \
+         state_prep_coeff.c world.c
+
+# Extra source compiled only for the shared library
+# (libphase2.so), not for ph2run.
+SRCS_SHARED_EXTRA := phase2_run.c
+
+# Backend-conditional sources (only some are built per
+# the active BACKEND, but all are *declared* so the
+# drift guard recognises them as known files).
+SRCS_BACKEND := qreg_qreg.c qreg_cuda.c \
+                qreg_cuda_lo.cu world_cuda.c
+
+OBJS          := $(SRCS:%.c=$(BUILDDIR)/phase2/%.o)
+SOBJS         := $(SRCS:%.c=$(BUILDDIR)/shared/phase2/%.o)	\
+                 $(BUILDDIR)/shared/phase2/phase2_run.o
+BACKEND_SOBJS := $(patsubst $(BUILDDIR)/%,$(BUILDDIR)/shared/%, $(BACKEND_OBJS))
+
+.PHONY: all shared check-srcs-coverage clean
+all:    $(OBJS) $(BACKEND_OBJS)
+shared: $(SOBJS) $(BACKEND_SOBJS)
+
+# NVCC compile rule for the one .cu source.  Only fires
+# when BACKEND=cuda places qreg_cuda_lo.o in
+# $(BACKEND_OBJS).
+$(BUILDDIR)/phase2/qreg_cuda_lo.o: qreg_cuda_lo.cu
+	@$(MKDIR) $(@D)
+	$(NVCC) $(NVCCFLAGS) $(BACKEND_CFLAGS) -I$(INCLUDE) -c $< -o $@
+
+$(BUILDDIR)/phase2/qreg_cuda_lo_dlink.o: $(BUILDDIR)/phase2/qreg_cuda_lo.o
+	$(NVCC) $(NVCCFLAGS) -dlink $< -o $@
+
+# Drift guard: every .c/.cu in this dir must appear in
+# SRCS, SRCS_SHARED_EXTRA, or SRCS_BACKEND.  Fails the
+# build if a new source slips in without being declared.
+check-srcs-coverage:
+	@declared=" $(SRCS) $(SRCS_SHARED_EXTRA) $(SRCS_BACKEND) ";	\
+	rc=0;								\
+	for s in *.c *.cu; do						\
+		[ -f "$$s" ] || continue;				\
+		case "$$declared" in *" $$s "*) ;;			\
+		*) echo "phase2: $$s missing from SRCS"; rc=1 ;;	\
+		esac;							\
+	done;								\
+	exit $$rc
+
+clean:
+	@$(RM) -r $(BUILDDIR)/phase2 $(BUILDDIR)/shared/phase2

--- a/python/phase2/__init__.py
+++ b/python/phase2/__init__.py
@@ -34,6 +34,11 @@ def _load_library() -> ctypes.CDLL:
 
     here = Path(__file__).resolve().parent
     candidates = [
+        # In-tree development build: python/phase2/ -> repo
+        # root, library lives at build/libphase2.so.
+        here / ".." / ".." / "build" / "libphase2.so",
+        # Legacy locations (older trees placed the .so at
+        # the repo root or inside an installed package).
         here / ".." / ".." / "libphase2.so",
         here / ".." / "libphase2.so",
         here / "libphase2.so",

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,11 +1,12 @@
 # ========================================================================== #
 # test -- C test suite, Python harness, cargo-style parallel runner          #
 #                                                                            #
-# Builds every t-*.c into a binary at $(TESTDIR)/t-* and the standalone      #
-# runner at $(TESTDIR)/run.  Owns the check / check-mpi / check-slow /       #
-# check-<filter> targets that delegate to the runner.  Two drift guards     #
-# live here: check-tests-coverage (every t-*.c is declared in TESTS) and    #
-# the per-subsys check-srcs-coverage (handled by sibling Makefiles).        #
+# Builds every t-*.c into a binary at $(BUILDDIR)/test/t-* and the           #
+# standalone runner at $(BUILDDIR)/test/run.  Owns the check / check-mpi /   #
+# check-slow / check-<filter> targets that delegate to the runner.  Two     #
+# drift guards live here: check-tests-coverage (every t-*.c is declared in  #
+# TESTS) and the per-subsys check-srcs-coverage (handled by sibling         #
+# Makefiles).                                                                #
 # ========================================================================== #
 
 ifndef TOPDIR
@@ -15,8 +16,8 @@ endif
 SUBSYS := test
 include $(TOPDIR)/build-rules.mk
 
-# Default-suite tests.  Names are listed bare; the
-# $(TESTDIR)/ prefix is added below.
+# Default-suite tests.  Names listed bare; the
+# $(BUILDDIR)/test/ prefix is added below.
 TESTS_BASE := \
 	t-bitstring_index t-circ_cache t-circ_prepst_coeff	\
 	t-circ_trott t-circ_trott2 t-circ_trott2_coeff		\
@@ -29,84 +30,86 @@ TESTS_BASE := \
 	t-state_prep_coeff_csf t-state_prep_coeff_expand	\
 	t-world
 
-TESTS      := $(TESTS_BASE:%=$(TESTDIR)/%)
-TESTS_SLOW := $(TESTDIR)/t-state_prep_coeff_large
+TBIN       := $(BUILDDIR)/test
+TESTS      := $(TESTS_BASE:%=$(TBIN)/%)
+TESTS_SLOW := $(TBIN)/t-state_prep_coeff_large
 PYTEST     := $(TESTDIR)/t-ref-coeff_matrix.py
 
 # Cargo-style parallel runner + synthetic fixtures
 # driven by t-run.
-RUNNER     := $(TESTDIR)/run
-RUNFIXDIR  := $(TESTDIR)/run-fixtures
+RUNNER     := $(TBIN)/run
+RUNFIXDIR  := $(TBIN)/run-fixtures
 RUNFIX     := $(addprefix $(RUNFIXDIR)/, pass fail sleep abort banner)
-
-# Tests compile with -DDEBUG (so log_trace / log_debug
-# in include/log.h expand to real emits).  Applied
-# below via target-specific CFLAGS so the more-specific
-# `-UDEBUG` on t-log_release lands later on the gcc
-# command line and wins (`last wins` rule for the C
-# preprocessor).
 
 # ----- Targets -------------------------------------------------------------
 .PHONY: build build-slow check check-mpi check-slow check-% \
-	check-tests-coverage clean distclean			\
+	check-tests-coverage clean				\
 	test-valgrind test-mpi-asan
 
 build: check-tests-coverage $(TESTS) $(RUNNER) $(RUNFIX)
 
 build-slow: $(TESTS_SLOW)
 
-# Test binary build.  Each t-X builds from t-X.c plus
-# the upstream subsys objects.  Inter-subsys link
-# prereqs (PHASE2OBJS, CIRCOBJS, LIBOBJS,
-# PH2RUN_DATA_OBJS) come from the top-level export.
+# Test binary build.  Each $(BUILDDIR)/test/t-X builds
+# from $(TESTDIR)/t-X.c plus the upstream subsys
+# objects.  Inter-subsys link prereqs (PHASE2OBJS,
+# CIRCOBJS, LIBOBJS, PH2RUN_DATA_OBJS) come from the
+# top-level export.  -DDEBUG is added via target-
+# specific CFLAGS so the more-specific -UDEBUG on
+# t-log_release lands later on the gcc command line
+# and wins (the C preprocessor's last-wins rule).
 $(TESTS) $(TESTS_SLOW): CFLAGS += -I$(TESTDIR) -I$(PHASE2DIR)		\
                                   -DPH2_TESTDIR=\"./test\"		\
                                   -DDEBUG -g -Og
 
-$(TESTS) $(TESTS_SLOW): $(TESTDIR)/%: $(TESTDIR)/%.c			\
+$(TESTS) $(TESTS_SLOW): $(TBIN)/%: $(TESTDIR)/%.c			\
                         $(TESTDIR)/test.h $(TESTDIR)/t-data.h		\
                         $(PHASE2OBJS) $(CIRCOBJS) $(LIBOBJS)		\
                         $(PH2RUN_DATA_OBJS)
+	@$(MKDIR) $(@D)
 	$(CC) $(CFLAGS) $(LDFLAGS) $< $(filter %.o, $^) $(LDLIBS) -o $@
 
-# Tests that need a specific algorithm object linked in
-# directly (the test file references the algorithm
+# Tests that need a specific algorithm object linked
+# in directly (the test file references the algorithm
 # symbols without going through phase2_run dispatch).
-$(TESTDIR)/t-circ_cache:        $(BUILDDIR)/circ/trott.o
-$(TESTDIR)/t-circ_trott:        $(BUILDDIR)/circ/trott.o
-$(TESTDIR)/t-circ_trott2:       $(BUILDDIR)/circ/trott2.o
-$(TESTDIR)/t-circ_trott_coeff:  $(BUILDDIR)/circ/trott.o
-$(TESTDIR)/t-circ_trott2_coeff: $(BUILDDIR)/circ/trott2.o
+$(TBIN)/t-circ_cache:        $(BUILDDIR)/circ/trott.o
+$(TBIN)/t-circ_trott:        $(BUILDDIR)/circ/trott.o
+$(TBIN)/t-circ_trott2:       $(BUILDDIR)/circ/trott2.o
+$(TBIN)/t-circ_trott_coeff:  $(BUILDDIR)/circ/trott.o
+$(TBIN)/t-circ_trott2_coeff: $(BUILDDIR)/circ/trott2.o
 
-# t-log_release cancels -DDEBUG to verify the release
-# build's strip of trace/debug macros.  The override
-# fires after TEST_CFLAGS via target-specific CFLAGS.
-$(TESTDIR)/t-log_release: CFLAGS += -UDEBUG
+# t-log_release verifies the release-build strip of
+# trace/debug macros: -UDEBUG cancels the -DDEBUG
+# inherited from the pattern target-specific above.
+$(TBIN)/t-log_release: CFLAGS += -UDEBUG
 
 # Cargo-style parallel runner: standalone C program,
 # libc + POSIX only.  No phase2 / MPI / HDF5 deps.
 $(RUNNER): $(TESTDIR)/run.c
+	@$(MKDIR) $(@D)
 	$(CC) -std=c11 -Wall -Wextra -O2 -o $@ $<
 
 # Synthetic fixtures used by t-run to exercise the
 # runner against controlled outcomes.
-$(RUNFIXDIR)/%: $(RUNFIXDIR)/%.c
+$(RUNFIXDIR)/%: $(TESTDIR)/run-fixtures/%.c
+	@$(MKDIR) $(@D)
 	$(CC) -std=c11 -Wall -Wextra -O2 -o $@ $<
 
-# t-run is a meta-test: it shells out to ./test/run
+# t-run is a meta-test: it shells out to the runner
 # against the fixtures.  Order-only prereqs ensure
 # they exist at runtime but stay out of the implicit
-# %: %.c link line (which would try to feed binaries
-# to ld).
-$(TESTDIR)/t-run: | $(RUNNER) $(RUNFIX)
+# %: %.c link line.
+$(TBIN)/t-run: | $(RUNNER) $(RUNFIX)
 
 # ----- Drift guard: every t-*.c is in TESTS or TESTS_SLOW -------------------
 check-tests-coverage:
 	@tmp=$$(mktemp -d);					\
 	ls $(TESTDIR)/t-*.c 2>/dev/null				\
-		| sed 's|\.c$$||' | sort > $$tmp/expected;	\
-	for t in $(TESTS) $(TESTS_SLOW); do echo $$t; done	\
-		| sort > $$tmp/declared;			\
+		| sed 's|^$(TESTDIR)/||; s|\.c$$||'		\
+		| sort > $$tmp/expected;			\
+	for t in $(TESTS) $(TESTS_SLOW); do			\
+		echo $${t##*/};					\
+	done | sort > $$tmp/declared;				\
 	missing=$$(comm -23 $$tmp/expected $$tmp/declared);	\
 	rc=0;							\
 	if [ -n "$$missing" ]; then				\
@@ -135,28 +138,25 @@ check-%: build
 
 # ----- Valgrind and MPI-ASan (do not go through the runner) -----------------
 test-valgrind: build
-	@for tt in $(TESTS); do						\
+	@cd $(TOPDIR) && for tt in $(TESTS); do				\
 		valgrind --quiet --error-exitcode=1			\
 			--leak-check=full				\
 			--errors-for-leak-kinds=all			\
-			--track-origins=yes ./$$tt &&			\
+			--track-origins=yes $$tt &&			\
 			echo "$$tt: OK" ||				\
 			( echo "$$tt: FAIL"; exit 1 );			\
 	done
 
 test-mpi-asan: build
-	@for tt in $(TESTDIR)/t-circ_trott_coeff; do			\
+	@cd $(TOPDIR) && for tt in $(TBIN)/t-circ_trott_coeff; do	\
 		$(MPIRUN) -n 4 $(MPIFLAGS)				\
-			-x ASAN_OPTIONS=$(ASAN_OPTIONS_VAL) ./$$tt &&	\
+			-x ASAN_OPTIONS=$(ASAN_OPTIONS_VAL) $$tt &&	\
 			echo "$$tt: OK" ||				\
 			( echo "$$tt: FAIL"; exit 1 );			\
 	done
 
 # ----- Clean ----------------------------------------------------------------
+# Test binaries + .d files all live under $(BUILDDIR)/test/; top-level
+# `make clean` wipes $(BUILDDIR) wholesale.  Nothing to clean here.
 clean:
-	@$(RM) -r $(BUILDDIR)/test
-	@$(RM) $(TESTDIR)/*.d
-
-distclean: clean
-	@$(RM) $(TESTS) $(TESTS_SLOW)
-	@$(RM) $(RUNNER) $(RUNFIX)
+	@:

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,0 +1,162 @@
+# ========================================================================== #
+# test -- C test suite, Python harness, cargo-style parallel runner          #
+#                                                                            #
+# Builds every t-*.c into a binary at $(TESTDIR)/t-* and the standalone      #
+# runner at $(TESTDIR)/run.  Owns the check / check-mpi / check-slow /       #
+# check-<filter> targets that delegate to the runner.  Two drift guards     #
+# live here: check-tests-coverage (every t-*.c is declared in TESTS) and    #
+# the per-subsys check-srcs-coverage (handled by sibling Makefiles).        #
+# ========================================================================== #
+
+ifndef TOPDIR
+$(error TOPDIR not set -- invoke via top-level Makefile, e.g. `make -C ..`)
+endif
+
+SUBSYS := test
+include $(TOPDIR)/build-rules.mk
+
+# Default-suite tests.  Names are listed bare; the
+# $(TESTDIR)/ prefix is added below.
+TESTS_BASE := \
+	t-bitstring_index t-circ_cache t-circ_prepst_coeff	\
+	t-circ_trott t-circ_trott2 t-circ_trott2_coeff		\
+	t-circ_trott_coeff t-circ t-combinations		\
+	t-data_attr t-data_coeff_matrix t-data_hamil		\
+	t-data_hamil_validate t-data_multidet t-data_open	\
+	t-data_dets_validate t-data_idempotence t-data_mpi	\
+	t-data_trott_steps t-det_small t-log t-log_release	\
+	t-paulis t-prob t-qreg t-ref-bendazzoli t-run		\
+	t-state_prep_coeff_csf t-state_prep_coeff_expand	\
+	t-world
+
+TESTS      := $(TESTS_BASE:%=$(TESTDIR)/%)
+TESTS_SLOW := $(TESTDIR)/t-state_prep_coeff_large
+PYTEST     := $(TESTDIR)/t-ref-coeff_matrix.py
+
+# Cargo-style parallel runner + synthetic fixtures
+# driven by t-run.
+RUNNER     := $(TESTDIR)/run
+RUNFIXDIR  := $(TESTDIR)/run-fixtures
+RUNFIX     := $(addprefix $(RUNFIXDIR)/, pass fail sleep abort banner)
+
+# Tests compile with -DDEBUG (so log_trace / log_debug
+# in include/log.h expand to real emits).  Applied
+# below via target-specific CFLAGS so the more-specific
+# `-UDEBUG` on t-log_release lands later on the gcc
+# command line and wins (`last wins` rule for the C
+# preprocessor).
+
+# ----- Targets -------------------------------------------------------------
+.PHONY: build build-slow check check-mpi check-slow check-% \
+	check-tests-coverage clean distclean			\
+	test-valgrind test-mpi-asan
+
+build: check-tests-coverage $(TESTS) $(RUNNER) $(RUNFIX)
+
+build-slow: $(TESTS_SLOW)
+
+# Test binary build.  Each t-X builds from t-X.c plus
+# the upstream subsys objects.  Inter-subsys link
+# prereqs (PHASE2OBJS, CIRCOBJS, LIBOBJS,
+# PH2RUN_DATA_OBJS) come from the top-level export.
+$(TESTS) $(TESTS_SLOW): CFLAGS += -I$(TESTDIR) -I$(PHASE2DIR)		\
+                                  -DPH2_TESTDIR=\"./test\"		\
+                                  -DDEBUG -g -Og
+
+$(TESTS) $(TESTS_SLOW): $(TESTDIR)/%: $(TESTDIR)/%.c			\
+                        $(TESTDIR)/test.h $(TESTDIR)/t-data.h		\
+                        $(PHASE2OBJS) $(CIRCOBJS) $(LIBOBJS)		\
+                        $(PH2RUN_DATA_OBJS)
+	$(CC) $(CFLAGS) $(LDFLAGS) $< $(filter %.o, $^) $(LDLIBS) -o $@
+
+# Tests that need a specific algorithm object linked in
+# directly (the test file references the algorithm
+# symbols without going through phase2_run dispatch).
+$(TESTDIR)/t-circ_cache:        $(BUILDDIR)/circ/trott.o
+$(TESTDIR)/t-circ_trott:        $(BUILDDIR)/circ/trott.o
+$(TESTDIR)/t-circ_trott2:       $(BUILDDIR)/circ/trott2.o
+$(TESTDIR)/t-circ_trott_coeff:  $(BUILDDIR)/circ/trott.o
+$(TESTDIR)/t-circ_trott2_coeff: $(BUILDDIR)/circ/trott2.o
+
+# t-log_release cancels -DDEBUG to verify the release
+# build's strip of trace/debug macros.  The override
+# fires after TEST_CFLAGS via target-specific CFLAGS.
+$(TESTDIR)/t-log_release: CFLAGS += -UDEBUG
+
+# Cargo-style parallel runner: standalone C program,
+# libc + POSIX only.  No phase2 / MPI / HDF5 deps.
+$(RUNNER): $(TESTDIR)/run.c
+	$(CC) -std=c11 -Wall -Wextra -O2 -o $@ $<
+
+# Synthetic fixtures used by t-run to exercise the
+# runner against controlled outcomes.
+$(RUNFIXDIR)/%: $(RUNFIXDIR)/%.c
+	$(CC) -std=c11 -Wall -Wextra -O2 -o $@ $<
+
+# t-run is a meta-test: it shells out to ./test/run
+# against the fixtures.  Order-only prereqs ensure
+# they exist at runtime but stay out of the implicit
+# %: %.c link line (which would try to feed binaries
+# to ld).
+$(TESTDIR)/t-run: | $(RUNNER) $(RUNFIX)
+
+# ----- Drift guard: every t-*.c is in TESTS or TESTS_SLOW -------------------
+check-tests-coverage:
+	@tmp=$$(mktemp -d);					\
+	ls $(TESTDIR)/t-*.c 2>/dev/null				\
+		| sed 's|\.c$$||' | sort > $$tmp/expected;	\
+	for t in $(TESTS) $(TESTS_SLOW); do echo $$t; done	\
+		| sort > $$tmp/declared;			\
+	missing=$$(comm -23 $$tmp/expected $$tmp/declared);	\
+	rc=0;							\
+	if [ -n "$$missing" ]; then				\
+		echo "test/: t-*.c files not in TESTS:";	\
+		echo "$$missing";				\
+		rc=1;						\
+	fi;							\
+	rm -rf $$tmp;						\
+	exit $$rc
+
+# ----- check targets (delegate to the runner) -------------------------------
+check: build
+	@cd $(TOPDIR) && $(RUNNER) -- $(TESTS) $(PYTEST)
+
+check-mpi: build
+	@cd $(TOPDIR) && $(RUNNER) --mpiranks=$(MPIRANKS) -- $(TESTS)
+
+check-slow: build-slow $(RUNNER)
+	@cd $(TOPDIR) && $(RUNNER) -- $(TESTS_SLOW)
+
+# Pattern: make check-data, check-paulis, check-circ,
+# etc. -- threads the stem as <stem>* fnmatch into
+# the runner.
+check-%: build
+	@cd $(TOPDIR) && $(RUNNER) --filter='$**' -- $(TESTS) $(PYTEST)
+
+# ----- Valgrind and MPI-ASan (do not go through the runner) -----------------
+test-valgrind: build
+	@for tt in $(TESTS); do						\
+		valgrind --quiet --error-exitcode=1			\
+			--leak-check=full				\
+			--errors-for-leak-kinds=all			\
+			--track-origins=yes ./$$tt &&			\
+			echo "$$tt: OK" ||				\
+			( echo "$$tt: FAIL"; exit 1 );			\
+	done
+
+test-mpi-asan: build
+	@for tt in $(TESTDIR)/t-circ_trott_coeff; do			\
+		$(MPIRUN) -n 4 $(MPIFLAGS)				\
+			-x ASAN_OPTIONS=$(ASAN_OPTIONS_VAL) ./$$tt &&	\
+			echo "$$tt: OK" ||				\
+			( echo "$$tt: FAIL"; exit 1 );			\
+	done
+
+# ----- Clean ----------------------------------------------------------------
+clean:
+	@$(RM) -r $(BUILDDIR)/test
+	@$(RM) $(TESTDIR)/*.d
+
+distclean: clean
+	@$(RM) $(TESTS) $(TESTS_SLOW)
+	@$(RM) $(RUNNER) $(RUNFIX)

--- a/test/t-ref-coeff_matrix.py
+++ b/test/t-ref-coeff_matrix.py
@@ -176,7 +176,10 @@ def compare(name: str, c_amps, py_amps) -> bool:
 
 
 def main():
-    binary = HERE / "t-state_prep_coeff_expand"
+    # The build places compiled artefacts under build/<srcdir>/.
+    # HERE is test/, so the helper binary lives at
+    # <repo>/build/test/t-state_prep_coeff_expand.
+    binary = HERE.parent / "build" / "test" / "t-state_prep_coeff_expand"
     if not binary.is_file() or not os.access(binary, os.X_OK):
         print(
             f"missing or non-executable {binary};"

--- a/test/t-run.c
+++ b/test/t-run.c
@@ -39,18 +39,22 @@
 
 #include "test.h"
 
-#ifndef PH2_TESTDIR
-#define PH2_TESTDIR "./test"
-#endif
-
-#define FIXDIR     PH2_TESTDIR "/run-fixtures"
+/*
+ * Runner binary, fixture binaries, and PH2_TESTDIR
+ * (used by sibling tests) all live under build/.
+ * t-run is invoked by the runner with cwd = repo
+ * root (see test/Makefile's `check` target), so
+ * relative paths under ./build/test work.
+ */
+#define TBIN       "./build/test"
+#define FIXDIR     TBIN "/run-fixtures"
 #define FIX_PASS   FIXDIR "/pass"
 #define FIX_FAIL   FIXDIR "/fail"
 #define FIX_SLEEP  FIXDIR "/sleep"
 #define FIX_ABORT  FIXDIR "/abort"
 #define FIX_BANNER FIXDIR "/banner"
 
-#define RUN_BIN    "./test/run"
+#define RUN_BIN    TBIN "/run"
 
 
 /* -- popen wrapper --------------------------------------------------- */


### PR DESCRIPTION
Rework the build system end-to-end.  Nine commits.


## Per-subsystem Makefiles

Split the ~530-line top-level driver into a
top-level orchestrator plus six per-subsystem
Makefiles (`phase2/`, `circ/`, `lib/`, `ph2run/`,
`bench/`, `test/`) under true recursive Make.  The
top-level invokes `$(MAKE) -C subsys` per target;
shared compile patterns live in a new
`build-rules.mk` included by each subsys Makefile.

The top-level reads in three labelled sections:

1. **USER CONFIGURATION** -- toolchain (`CC`,
   `CFLAGS`, `EXTRA_CFLAGS`), MPI library paths,
   HDF5 paths, backend selection, build output
   directory, version.  A user porting phase2 to a
   new machine edits this block only.
2. **INTERNAL** -- subsystem layout, derived OBJS
   unions, CFLAGS/LDFLAGS pipeline, the `export`
   contract that makes Section 1 values visible to
   sub-makes.
3. **TARGETS** -- per-subsys dispatch and the
   high-level user-facing targets.

Sub-makes refuse to run standalone (`make -C
phase2`) -- they error with a pointer at the
top-level driver.  `make phase2` from the top
dispatches correctly.

Each subsys Makefile owns its source list, derives
its objects via `SRCS -> build/<subsys>/*.o`, and
provides `all` / `shared` / `check-srcs-coverage`
targets.  `ph2run` and `bench` own their link rules
(the binaries cross subsystem boundaries and consume
the exported OBJS unions).  `test/` owns the TESTS
list, the cargo-style runner build, the
run-fixtures, the `check-tests-coverage` drift
guard, and the `check` / `check-mpi` / `check-slow`
/ `check-<filter>` targets.


## Everything under `build/`

All compile artefacts -- objects, header-dep
files, executable binaries, the shared library --
land under `build/<srcdir>/`, mirroring the source
tree:

    phase2/circ.c      ->  build/phase2/circ.o + .d
    lib/log.c          ->  build/lib/log.o     + .d
    ph2run/ph2run.c    ->  build/ph2run/ph2run
    test/t-paulis.c    ->  build/test/t-paulis
    test/run.c         ->  build/test/run
    bench/b-paulis.c   ->  build/bench/b-paulis
    (shared lib)       ->  build/libphase2.so

Source directories stay clean; nothing executable
lives next to the `.c` sources.  `make clean`
collapses to `rm -rf build/`.  The `shared` target
compiles the same sources with `-fPIC` into a
disjoint tree at `build/shared/<srcdir>/`, so
`make build` and `make shared` (in either order)
never mix PIC and non-PIC objects.

Callers updated: `test/t-run.c` references the new
fixture path; `test/t-ref-coeff_matrix.py` looks
for its helper at `build/test/`; the Python
wrapper's library-search prepends
`build/libphase2.so`; the README and `doc/logging.md`
example commands use the `./build/ph2run/ph2run`
path; `doc/python.md` notes the new shared-library
location.


## Auto-dep tracking (`-MMD -MP`)

Header prerequisites for every `.c -> .o` were
hand-declared in the Makefile, and several entries
were incomplete (`phase2/circ.o` omitted
`paulis.h`; `phase2/qreg.o` omitted `paulis.h`,
`world.h`, `log.h`; `phase2/world.o` omitted
`xoshiro256ss.h`, `log.h`; etc.).  Touching any of
those headers silently failed to rebuild dependent
objects.

`-MMD -MP` in `CFLAGS` makes `gcc` emit a `<obj>.d`
next to every `.o`, listing every header the `.c`
`#include`'d transitively plus empty fallback rules
so a renamed header doesn't break the build.  The
top-level `-include`s the dep set at its foot.
Every per-`.o` header-prereq line goes away.

Smoke test: `touch include/phase2/paulis.h && make
build` correctly rebuilds nine dependent objects
(was one).


## Source-coverage drift guard

A `.c` or `.cu` dropped under `phase2/`, `circ/`,
`lib/`, `ph2run/`, or `bench/` and not wired into
an `OBJS` set would silently fail to compile.
Each subsys Makefile now carries a
`check-srcs-coverage` rule that enumerates its own
sources and fails the build if any aren't in the
subsys's `SRCS` list.  The top-level
`check-srcs-coverage` (a prerequisite of `build`)
dispatches each subsys's check.

Mirrors `check-tests-coverage` on the test side
(test-subsystem audit, PR #30).


## Hygiene and tidying

- `.PHONY` listed `bulid-bench` (typo); the real
  target `build-bench` therefore had no phony
  marker.  Fixed.
- `.gitignore` pruned: every compile artefact now
  lives under `build/`, so the per-language
  wildcards (`*.o`, `*.d`, `*.so`, ...) and the
  per-binary entries (`ph2run/ph2run`,
  `bench/b-*`, `test/t-*`, etc.) collapse to a
  single `build/`.  Drops ~80 lines of patterns
  inherited from a generic C++/CMake/Windows
  template that never matched anything in this
  tree.


## Documentation

- `doc/phase2.md` §10.5 covers the recursive
  layout, the three-section top-level shape, the
  build/ layout, auto-dep tracking, the
  shared-library PIC tree, the per-subsys drift
  guard, and a "how to add a new subsystem"
  recipe.
- `doc/testing.md` updated to reflect that test
  binaries and the runner live under `build/test/`.
- `README.md`, `doc/logging.md`, `doc/python.md`
  refreshed for the new artefact locations.


## Test plan

- `make clean && make -j$(nproc) all` -- clean
  parallel scratch build, no errors.
- `make check` -- 31/31 OK.
- `make check-mpi MPIRANKS=2` -- 30/30 OK.
- `make check-slow` -- 1/1 OK.
- `make check-data`, `check-paulis`, `check-circ`
  filter to the expected subsets.
- `touch include/phase2/paulis.h && make build`
  -- 9 dependent objects rebuild.
- Drift detection: `touch phase2/zfake.c && make
  build` fails with the offender named; revert.
- `make build && make shared` -- both binary and
  PIC layouts coexist under `build/` and
  `build/shared/`.
- `make -C phase2` errors with a pointer at the
  top-level driver; `make phase2` works.
- `find phase2 circ lib ph2run bench test -name
  '*.o' -o -name '*.d'` -- empty after a clean
  build.
- `python -c "import phase2"` after `make shared`
  -- loads from `build/libphase2.so`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
