### PR TITLE
circ: drop circ_prog, instance-based cache, API tightness, docs

### DIFF
--- a/circ/cmpsit.c
+++ b/circ/cmpsit.c
@@ -228,8 +228,6 @@ int cmpsit_simul(struct cmpsit *cp)
 		vals->len, cp->dt.steps, cp->dt.length, cp->dt.depth,
 		cp->dt.angle_det, cp->dt.angle_rand);
 
-	struct circ_prog prog;
-	circ_prog_init(&prog, vals->len, "sample");
 	for (size_t i = 0; i < vals->len; i++) {
 		log_debug("sample %zu/%zu", i + 1, vals->len);
 		circ_prepst(ct);
@@ -265,8 +263,6 @@ int cmpsit_simul(struct cmpsit *cp)
 			log_error("cmpsit_simul: write_step %zu failed", i);
 			return -1;
 		}
-		circ_prog_tick(&prog);
-		circ_prog_emit(&prog, LOG_SUBSYS);
 	}
 
 	return 0;

--- a/circ/qdrift.c
+++ b/circ/qdrift.c
@@ -115,8 +115,6 @@ int qdrift_simul(struct qdrift *qd)
 		vals->len, qd->dt.depth, qd->dt.step_size,
 		(unsigned long)qd->dt.seed, qd->ranct.cdf.len);
 
-	struct circ_prog prog;
-	circ_prog_init(&prog, vals->len, "sample");
 	for (size_t i = 0; i < vals->len; i++) {
 		log_debug("sample %zu/%zu", i + 1, vals->len);
 		circ_prepst(ct);
@@ -133,9 +131,6 @@ int qdrift_simul(struct qdrift *qd)
 			log_error("qdrift_simul: write_step %zu failed", i);
 			return -1;
 		}
-
-		circ_prog_tick(&prog);
-		circ_prog_emit(&prog, LOG_SUBSYS);
 	}
 
 	return 0;

--- a/circ/trott.c
+++ b/circ/trott.c
@@ -39,9 +39,6 @@ int trott_simul(struct trott *tt)
 	struct circ *ct = &tt->ct;
 	struct circ_values *vals = &ct->vals;
 
-	struct circ_prog prog;
-	circ_prog_init(&prog, vals->len, "step");
-
 	circ_prepst(ct);
 	for (size_t i = 0; i < vals->len; i++) {
 		log_debug("step %zu/%zu", i + 1, vals->len);
@@ -55,9 +52,6 @@ int trott_simul(struct trott *tt)
 			log_error("trott_simul: write_step %zu failed", i);
 			return -1;
 		}
-
-		circ_prog_tick(&prog);
-		circ_prog_emit(&prog, LOG_SUBSYS);
 	}
 
 	return 0;

--- a/circ/trott2.c
+++ b/circ/trott2.c
@@ -39,9 +39,6 @@ int trott2_simul(struct trott2 *t2)
 	struct circ *ct = &t2->ct;
 	struct circ_values *vals = &ct->vals;
 
-	struct circ_prog prog;
-	circ_prog_init(&prog, vals->len, "step");
-
 	const double half = t2->dt.delta / 2.0;
 
 	circ_prepst(ct);
@@ -64,9 +61,6 @@ int trott2_simul(struct trott2 *t2)
 			log_error("trott2_simul: write_step %zu failed", i);
 			return -1;
 		}
-
-		circ_prog_tick(&prog);
-		circ_prog_emit(&prog, LOG_SUBSYS);
 	}
 
 	return 0;

--- a/doc/phase2.md
+++ b/doc/phase2.md
@@ -221,13 +221,17 @@ Pauli string require the same MPI exchange pattern.  Since
 MPI exchange is the dominant cost, the library batches such
 terms to amortise the communication overhead.
 
-The `circ_cache` module is a static accumulator that stores
-up to CACHE_MAX = 1024 (lo-qubit code, angle) pairs.
-Terms are inserted via `circ_cache_insert`.  When a term
-with a different hi-part arrives, or the cache is full, the
-accumulated batch is flushed: a single MPI exchange is
-performed, followed by CACHE_MAX (or fewer) local rotation
-passes.
+The `circ_cache` module is an accumulator that stores up
+to CACHE_MAX = 1024 (lo-qubit code, angle) pairs.  Each
+`struct circ` owns its own `struct circ_cache` instance
+(allocated in `circ_init`, freed in `circ_free`), so
+multi-circuit drivers and the Python `ctypes` entry point
+can hold several active circuits concurrently.  Terms are
+inserted via `circ_cache_insert(cache, ...)`.  When a
+term with a different hi-part arrives, or the cache is
+full, the accumulated batch is flushed: a single MPI
+exchange is performed, followed by CACHE_MAX (or fewer)
+local rotation passes.
 
 Sorting the Hamiltonian lexicographically
 (`circ_hamil_sort_lex`) before simulation maximises the
@@ -297,20 +301,37 @@ computing each step's overlap, the algorithm calls
 disables per-step output and runs the simulation entirely
 in memory.
 
-ph2run plugs in a writer whose `ctx` is a
-`struct data_circ_writer` (the HDF5 dataset cache from
-the data subsystem) and whose `write` thunks to
-`data_circ_write_step`:
+ph2run plugs in a writer whose context bundles the HDF5
+dataset cache from the data subsystem together with the
+fields it needs for progress emission (total steps,
+wall-clock start, last emitted percent, unit name).
+The thunk writes the result, then emits a progress line
+at INFO level whenever a new percent boundary is
+crossed:
 
 ```c
+struct step_ctx {
+        struct data_circ_writer *wr;
+        size_t total;
+        struct timespec t0;
+        unsigned last_pc;
+        const char *unit;     /* "step" / "sample" */
+};
+
 static int step_thunk(void *ctx, size_t i,
         _Complex double z)
 {
-        return data_circ_write_step(ctx, i, z);
+        struct step_ctx *sc = ctx;
+        if (data_circ_write_step(sc->wr, i, z) < 0)
+                return -1;
+        /* ... emit progress line on percent boundary ... */
+        return 0;
 }
-struct phase2_step_writer sw = {
-        .ctx = &io.wr, .write = step_thunk };
 ```
+
+The compute library (circ + algorithms) carries no
+progress emitter of its own.  All telemetry lives
+on the application side, behind this one callback.
 
 External wrappers (Python via ctypes, future C/Rust
 callers) plug in whatever sink they want, without

--- a/include/phase2/circ.h
+++ b/include/phase2/circ.h
@@ -1,6 +1,31 @@
 #ifndef CIRC_H
 #define CIRC_H
 
+/*
+ * phase2/circ.h -- circuit context, data carriers, and
+ * the lifecycle / step / measure API.
+ *
+ * `struct circ` is the per-simulation aggregate: it owns
+ * a Pauli Hamiltonian, a state-prep payload (multidet or
+ * coeff_matrix), an MPI-distributed register, a batch
+ * cache, and the per-step results buffer.
+ *
+ * The carriers below (`circ_hamil`, `circ_muldet`,
+ * `circ_values`, plus the coefficient-matrix payloads
+ * `data_coeff_matrix` / `data_coeff_block`) are populated
+ * either by the data subsystem (`ph2run/data.h`) or in-
+ * tree by test code.  The free helpers here are pure
+ * pointer cleanup and do not depend on HDF5, so circ /
+ * libphase2.so can release them without linking the I/O
+ * layer.
+ *
+ * Algorithms (`circ/trott.c`, `trott2.c`, `qdrift.c`,
+ * `cmpsit.c`) build a `struct circ`, prepare the state,
+ * run a sequence of `circ_step` / `circ_step_reverse`
+ * calls, and read out each step's overlap with
+ * `circ_measure`.
+ */
+
 #include <stddef.h>
 #include <stdint.h>
 
@@ -8,6 +33,17 @@
 #include "phase2/qreg.h"
 #include "phase2/state_prep_coeff.h"
 
+/*
+ * Sparse Hamiltonian: a sum of weighted Pauli strings.
+ *
+ *   qb     qubit count the operators apply to.
+ *   terms  array of (coefficient, packed Pauli) pairs.
+ *   len    number of terms.
+ *
+ * Allocated by `circ_hamil_init`; freed by
+ * `circ_hamil_free`.  Ownership is transferred to a
+ * `struct circ` on a successful `circ_init`.
+ */
 struct circ_hamil {
 	uint32_t qb;
 	struct circ_hamil_term {
@@ -17,6 +53,14 @@ struct circ_hamil {
 	size_t len;
 };
 
+/*
+ * Multi-determinant state-prep payload: a sparse
+ * superposition |psi> = sum_i cf_i |idx_i>.
+ *
+ *   dets   array of (basis-state index, complex
+ *          amplitude) pairs.
+ *   len    number of basis states.
+ */
 struct circ_muldet {
 	struct {
 		uint64_t idx;
@@ -25,6 +69,11 @@ struct circ_muldet {
 	size_t len;
 };
 
+/*
+ * Per-step results: one complex overlap per Trotter
+ * step (or qDRIFT / composite sample), filled in by
+ * the algorithm during simulation.
+ */
 struct circ_values {
 	_Complex double *z;
 	size_t len;
@@ -94,6 +143,29 @@ struct data_coeff_matrix {
 	struct data_coeff_block *blocks;
 };
 
+/*
+ * Per-simulation aggregate.  Members:
+ *
+ *   hm           sparse Pauli Hamiltonian; adopted by
+ *                circ_init, freed by circ_free.
+ *   md           multidet state-prep payload; populated
+ *                when stprep_kind == STPREP_MULTIDET.
+ *   cache        Pauli-rotation batch cache (private
+ *                type, allocated in circ_init, freed in
+ *                circ_free).
+ *   vals         per-step results buffer.
+ *   reg          MPI-distributed quantum register.
+ *   stprep_kind  selects which state-prep payload to
+ *                consume (md vs cm).
+ *   cm           coefficient-matrix state-prep payload;
+ *                populated when stprep_kind ==
+ *                STPREP_COEFF_MATRIX.
+ *
+ * Callers do not poke at internal fields directly --
+ * the lifecycle goes through circ_init / circ_free,
+ * the simulation through circ_prepst / circ_step /
+ * circ_measure.
+ */
 struct circ {
 	struct circ_hamil hm;
 	struct circ_muldet md;
@@ -104,10 +176,38 @@ struct circ {
 	struct data_coeff_matrix cm;
 };
 
+
+/* -- data carriers ------------------------------------------------------- */
+
+/*
+ * circ_hamil_init / _free / _sort_lex -- allocate,
+ * release, and pre-sort a Hamiltonian carrier.
+ *
+ * `_init` allocates `len` term slots and records the
+ * qubit count; returns 0 on success, -1 on
+ * allocation failure.
+ *
+ * `_free` releases the term buffer and zeroes both the
+ * pointer and `len`, so a second free is a clean
+ * no-op.  Safe to call on a default-zero `struct
+ * circ_hamil`.
+ *
+ * `_sort_lex` reorders terms by lexicographic Pauli
+ * code, which groups terms sharing an MPI exchange
+ * contiguously and maximises the batch cache hit rate
+ * in circ_step.  Cheap to run; do once before the
+ * first step.
+ */
 int circ_hamil_init(struct circ_hamil *hm, uint32_t qb, size_t len);
 void circ_hamil_free(struct circ_hamil *hm);
 void circ_hamil_sort_lex(struct circ_hamil *hm);
 
+/*
+ * circ_muldet_init / _free -- allocate and release the
+ * multi-determinant state-prep carrier.  `_init`
+ * returns 0 on success, -1 on allocation failure;
+ * `_free` is idempotent.
+ */
 int circ_muldet_init(struct circ_muldet *md, size_t len);
 void circ_muldet_free(struct circ_muldet *md);
 
@@ -118,8 +218,17 @@ void circ_muldet_free(struct circ_muldet *md);
  * not depend on HDF5. */
 void data_coeff_matrix_free(struct data_coeff_matrix *cm);
 
+/*
+ * circ_values_init / _free -- allocate and release the
+ * per-step results buffer (`len` complex slots).
+ * `_init` returns 0 on success, -1 on allocation
+ * failure; `_free` is idempotent.
+ */
 int circ_values_init(struct circ_values *vals, size_t len);
 void circ_values_free(struct circ_values *vals);
+
+
+/* -- lifecycle ----------------------------------------------------------- */
 
 /*
  * circ_init - adopt pre-loaded Hamiltonian and state-prep
@@ -143,11 +252,49 @@ void circ_values_free(struct circ_values *vals);
  */
 int circ_init(struct circ *ct, struct circ_hamil hm,
 	enum stprep_kind sp_kind, const void *sp_data, size_t vals_len);
+
+/* Release every owned buffer (Hamiltonian, state-prep
+ * payload, cache, register, results) and zero the
+ * cache pointer.  Safe on a fully-initialised circ. */
 void circ_free(struct circ *ct);
+
+
+/* -- simulation surface -------------------------------------------------- */
+
+/*
+ * circ_prepst -- write the initial state encoded by the
+ * adopted state-prep payload into the MPI register.
+ * Zeroes the register first.  Returns 0 on success, -1
+ * on error.
+ */
 int circ_prepst(struct circ *ct);
+
+/*
+ * circ_step / circ_step_reverse -- apply one Trotter step
+ * exp(i*omega*H), traversing the Hamiltonian forward or
+ * backward respectively.  Forward and reverse sweeps with
+ * the same omega cancel only when each Pauli rotation
+ * commutes with the next, hence the order matters for
+ * Strang-style 2nd-order Trotter.
+ *
+ * Returns 0 on success, -1 on error (e.g. a cache flush
+ * could not place the next term).
+ */
 int circ_step(struct circ *ct, const struct circ_hamil *hm, double omega);
 int circ_step_reverse(
 	struct circ *ct, const struct circ_hamil *hm, double omega);
+
+/*
+ * circ_measure -- compute <trial | evolved>, where the
+ * trial state is determined by the adopted state-prep
+ * payload and `evolved` is the register's current
+ * contents.  Returns the complex overlap.
+ *
+ * Sentinel: returns 0+0i if `ct->stprep_kind` is not
+ * one of the known enum values (the switch has no
+ * default; this path is unreachable on a well-formed
+ * circ but kept defensively).
+ */
 _Complex double circ_measure(struct circ *ct);
 
 #endif // CIRC_H

--- a/include/phase2/circ.h
+++ b/include/phase2/circ.h
@@ -3,7 +3,6 @@
 
 #include <stddef.h>
 #include <stdint.h>
-#include <time.h>
 
 #include "phase2/paulis.h"
 #include "phase2/qreg.h"
@@ -24,13 +23,6 @@ struct circ_muldet {
 		_Complex double cf;
 	} *dets;
 	size_t len;
-};
-
-struct circ_prog {
-	unsigned pc;	/* percent of len */
-	size_t i, len;
-	struct timespec t0;	/* wall-clock start for ETA */
-	const char *unit;	/* "step", "sample"; never NULL */
 };
 
 struct circ_values {
@@ -125,16 +117,6 @@ void circ_muldet_free(struct circ_muldet *md);
  * Lives here because it is pure pointer cleanup and does
  * not depend on HDF5. */
 void data_coeff_matrix_free(struct data_coeff_matrix *cm);
-
-void circ_prog_init(struct circ_prog *prog, size_t len, const char *unit);
-void circ_prog_tick(struct circ_prog *prog);
-/* Format a rich progress line and emit it at info level
- * through the given subsystem tag:
- *
- *   step 17/100 (17%) elapsed 4.31s eta 21.0s
- *
- * Callers control cadence; the library does not throttle. */
-void circ_prog_emit(const struct circ_prog *prog, const char *subsys);
 
 int circ_values_init(struct circ_values *vals, size_t len);
 void circ_values_free(struct circ_values *vals);

--- a/ph2run/ph2run.c
+++ b/ph2run/ph2run.c
@@ -93,9 +93,56 @@ static void cmd_inputs_close(struct cmd_inputs *io)
 	data_close(io->fid);
 }
 
+/*
+ * Per-step callback for the algorithm's
+ * phase2_step_writer hook.  Writes the result to the
+ * HDF5 sink and emits a progress line at INFO level
+ * once per crossed percent boundary.  All progress
+ * telemetry for ph2run lives here -- the circ
+ * library is pure compute.
+ */
+struct step_ctx {
+	struct data_circ_writer *wr;
+	size_t total;		/* total number of steps */
+	struct timespec t0;	/* wall-clock start for ETA */
+	unsigned last_pc;	/* most recent emitted percent */
+	const char *unit;	/* "step", "sample"; never NULL */
+};
+
+static void step_ctx_init(struct step_ctx *sc, struct data_circ_writer *wr,
+	size_t total, const char *unit)
+{
+	sc->wr = wr;
+	sc->total = total;
+	sc->last_pc = 0;
+	sc->unit = unit ? unit : "step";
+	clock_gettime(CLOCK_MONOTONIC, &sc->t0);
+}
+
 static int step_thunk(void *ctx, size_t i, _Complex double z)
 {
-	return data_circ_write_step(ctx, i, z);
+	struct step_ctx *sc = ctx;
+	if (data_circ_write_step(sc->wr, i, z) < 0)
+		return -1;
+
+	const size_t done = i + 1;
+	const unsigned pc = (sc->total > 0)
+		? (unsigned)(done * 100 / sc->total)
+		: 0;
+	if (pc > sc->last_pc) {
+		sc->last_pc = pc;
+		struct timespec now;
+		clock_gettime(CLOCK_MONOTONIC, &now);
+		const double elapsed = (now.tv_sec - sc->t0.tv_sec)
+			+ (now.tv_nsec - sc->t0.tv_nsec) * 1e-9;
+		const double frac = (double)done / (double)sc->total;
+		const double eta = (frac > 0.0)
+			? elapsed * (1.0 / frac - 1.0)
+			: 0.0;
+		log_info("%s %zu/%zu (%u%%) elapsed %.2fs eta %.2fs",
+			sc->unit, done, sc->total, pc, elapsed, eta);
+	}
+	return 0;
 }
 
 #define WD_SEED UINT64_C(0xd326119d4859ebb2)
@@ -270,7 +317,9 @@ static int cmd_trott(void)
 	log_info("*** Circuit: trott ***");
 	log_info("delta: %f", cmd_trott_dt.tt_dt.delta);
 	log_info("num_steps: %zu", cmd_trott_dt.tt_dt.steps);
-	struct phase2_step_writer sw = { .ctx = &io.wr, .write = step_thunk };
+	struct step_ctx sc;
+	step_ctx_init(&sc, &io.wr, cmd_trott_dt.tt_dt.steps, "step");
+	struct phase2_step_writer sw = { .ctx = &sc, .write = step_thunk };
 	if (trott_init(&cmd_trott_dt.tt, &cmd_trott_dt.tt_dt, io.hm,
 		    io.sp_kind, cmd_inputs_sp_data(&io), &sw) < 0) {
 		log_error("trott: init failed");
@@ -382,7 +431,9 @@ static int cmd_trott2(void)
 	log_info("*** Circuit: trott2 (Strang 2nd-order) ***");
 	log_info("delta: %f", cmd_trott2_dt.t2_dt.delta);
 	log_info("num_steps: %zu", cmd_trott2_dt.t2_dt.steps);
-	struct phase2_step_writer sw = { .ctx = &io.wr, .write = step_thunk };
+	struct step_ctx sc;
+	step_ctx_init(&sc, &io.wr, cmd_trott2_dt.t2_dt.steps, "step");
+	struct phase2_step_writer sw = { .ctx = &sc, .write = step_thunk };
 	if (trott2_init(&cmd_trott2_dt.t2, &cmd_trott2_dt.t2_dt, io.hm,
 		    io.sp_kind, cmd_inputs_sp_data(&io), &sw) < 0) {
 		log_error("trott2: init failed");
@@ -507,7 +558,9 @@ int cmd_qdrift(void)
 	log_info("depth: %zu", cmd_qdrift_dt.qd_dt.depth);
 	log_info("samples: %zu", cmd_qdrift_dt.qd_dt.samples);
 	log_info("seed: %lu", cmd_qdrift_dt.qd_dt.seed);
-	struct phase2_step_writer sw = { .ctx = &io.wr, .write = step_thunk };
+	struct step_ctx sc;
+	step_ctx_init(&sc, &io.wr, cmd_qdrift_dt.qd_dt.samples, "sample");
+	struct phase2_step_writer sw = { .ctx = &sc, .write = step_thunk };
 	if (qdrift_init(&cmd_qdrift_dt.qd, &cmd_qdrift_dt.qd_dt, io.hm,
 		    io.sp_kind, cmd_inputs_sp_data(&io), &sw) < 0) {
 		log_error("qdrift: init failed");
@@ -673,7 +726,9 @@ int cmd_cmpsit(void)
 	log_info("angle_det: %.16f", cmd_cmpsit_dt.cp_dt.angle_det);
 	log_info("angle_rand: %.16f", cmd_cmpsit_dt.cp_dt.angle_rand);
 	log_info("samples: %zu", cmd_cmpsit_dt.cp_dt.samples);
-	struct phase2_step_writer sw = { .ctx = &io.wr, .write = step_thunk };
+	struct step_ctx sc;
+	step_ctx_init(&sc, &io.wr, cmd_cmpsit_dt.cp_dt.samples, "sample");
+	struct phase2_step_writer sw = { .ctx = &sc, .write = step_thunk };
 	if (cmpsit_init(&cmd_cmpsit_dt.cp, &cmd_cmpsit_dt.cp_dt, io.hm,
 		    io.sp_kind, cmd_inputs_sp_data(&io), &sw) < 0) {
 		log_error("cmpsit: init failed");

--- a/phase2/circ.c
+++ b/phase2/circ.c
@@ -1,3 +1,27 @@
+/*
+ * phase2/circ.c -- implementation of the circ API
+ * declared in include/phase2/circ.h.
+ *
+ * Layout:
+ *   - data-carrier helpers (hamil / muldet / values)
+ *     and the coeff-matrix free,
+ *   - lifecycle (circ_init / circ_free),
+ *   - state preparation (circ_prepst),
+ *   - Hamiltonian step (circ_step / _reverse, sharing
+ *     circ_step_generic) and its batch-cache callback
+ *     circ_flush,
+ *   - measurement (circ_measure, with the
+ *     coeff-matrix helpers measure_coeff /
+ *     measure_coeff_block).
+ *
+ * The batch cache lives in `circ_cache.{c,h}`
+ * (phase2-private header) and is opaque from this
+ * file's perspective; each `struct circ` owns its own
+ * `struct circ_cache` instance.  The four algorithm
+ * drivers (trott / trott2 / qdrift / cmpsit) live in
+ * `circ/` and consume this surface.
+ */
+
 #include "c23_compat.h"
 #include <complex.h>
 #include <math.h>
@@ -314,5 +338,10 @@ _Complex double circ_measure(struct circ *ct)
 		return measure_coeff(ct);
 	}
 
+	/* Unreachable on a well-formed circ -- circ_init
+	 * validates stprep_kind.  Sentinel return so the
+	 * compiler is happy without a default case (which
+	 * would suppress the warning when a future
+	 * stprep_kind is added). */
 	return 0.0;
 }

--- a/phase2/circ.c
+++ b/phase2/circ.c
@@ -28,8 +28,9 @@ int circ_hamil_init(struct circ_hamil *hm, uint32_t qb, size_t len)
 
 void circ_hamil_free(struct circ_hamil *hm)
 {
-	if (hm->terms != nullptr)
-		free(hm->terms);
+	free(hm->terms);
+	hm->terms = nullptr;
+	hm->len = 0;
 }
 
 static int hamil_term_cmp_lex(const void *a, const void *b)
@@ -64,8 +65,9 @@ int circ_muldet_init(struct circ_muldet *md, size_t len)
 
 void circ_muldet_free(struct circ_muldet *md)
 {
-	if (md->dets != nullptr)
-		free(md->dets);
+	free(md->dets);
+	md->dets = nullptr;
+	md->len = 0;
 }
 
 void data_coeff_matrix_free(struct data_coeff_matrix *cm)
@@ -99,11 +101,12 @@ int circ_values_init(struct circ_values *vals, size_t len)
 void circ_values_free(struct circ_values *vals)
 {
 	free(vals->z);
+	vals->z = nullptr;
+	vals->len = 0;
 }
 
 int circ_init(struct circ *ct, struct circ_hamil hm,
-	const enum stprep_kind sp_kind, const void *sp_data,
-	const size_t vals_len)
+	enum stprep_kind sp_kind, const void *sp_data, size_t vals_len)
 {
 	memset(&ct->md, 0, sizeof ct->md);
 	memset(&ct->cm, 0, sizeof ct->cm);
@@ -216,7 +219,7 @@ static void circ_flush(struct paulis code_hi, const struct paulis *codes_lo,
  * identical hi codes are contiguous — see circ_hamil_sort_lex.
  */
 static int circ_step_generic(struct circ *ct, const struct circ_hamil *hm,
-	const double omega, bool reverse)
+	double omega, bool reverse)
 {
 	for (size_t i = 0; i < hm->len; i++) {
 		size_t j = i;
@@ -241,14 +244,14 @@ static int circ_step_generic(struct circ *ct, const struct circ_hamil *hm,
 	return 0;
 }
 
-inline int circ_step(
-	struct circ *ct, const struct circ_hamil *hm, const double omega)
+inline int circ_step(struct circ *ct, const struct circ_hamil *hm,
+	double omega)
 {
 	return circ_step_generic(ct, hm, omega, false);
 }
 
-inline int circ_step_reverse(
-	struct circ *ct, const struct circ_hamil *hm, const double omega)
+inline int circ_step_reverse(struct circ *ct, const struct circ_hamil *hm,
+	double omega)
 {
 	return circ_step_generic(ct, hm, omega, true);
 }
@@ -263,9 +266,9 @@ inline int circ_step_reverse(
  * same order as expansion itself.
  */
 static _Complex double measure_coeff_block(struct qreg *reg,
-	const uint32_t n_sites, const uint32_t n_alpha, const uint32_t n_beta,
-	const double *C_alpha, const double *C_beta, const double weight,
-	const int tapered)
+	uint32_t n_sites, uint32_t n_alpha, uint32_t n_beta,
+	const double *C_alpha, const double *C_beta, double weight,
+	int tapered)
 {
 	return state_prep_coeff_inner(reg, n_sites, n_alpha, n_beta, C_alpha,
 		C_beta, weight, tapered);

--- a/phase2/circ.c
+++ b/phase2/circ.c
@@ -1,6 +1,3 @@
-/* clock_gettime for circ_prog timing. */
-#define _POSIX_C_SOURCE 200809L
-
 #include "c23_compat.h"
 #include <complex.h>
 #include <math.h>
@@ -9,7 +6,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <time.h>
 
 #define LOG_SUBSYS "circ"
 #include "log.h"
@@ -86,48 +82,6 @@ void data_coeff_matrix_free(struct data_coeff_matrix *cm)
 	free((void *)cm->C_alpha);
 	free((void *)cm->C_beta);
 	memset(cm, 0, sizeof *cm);
-}
-
-void circ_prog_init(struct circ_prog *prog, size_t len, const char *unit)
-{
-	prog->i = 0;
-	prog->len = len;
-	prog->pc = 0;
-	prog->unit = unit ? unit : "step";
-	clock_gettime(CLOCK_MONOTONIC, &prog->t0);
-}
-
-void circ_prog_tick(struct circ_prog *prog)
-{
-	prog->i++;
-
-	const unsigned pc = prog->i * 100 / prog->len;
-	if (pc > prog->pc) {
-		prog->pc = pc;
-		log_debug("progress: %u%%", prog->pc);
-	}
-}
-
-void circ_prog_emit(const struct circ_prog *prog, const char *subsys)
-{
-	if (LOG_INFO < log_threshold)
-		return;
-
-	struct timespec now;
-	clock_gettime(CLOCK_MONOTONIC, &now);
-	const double elapsed = (now.tv_sec - prog->t0.tv_sec) +
-		(now.tv_nsec - prog->t0.tv_nsec) * 1e-9;
-	const double frac = (prog->len > 0)
-		? (double)prog->i / (double)prog->len
-		: 0.0;
-	const double eta = (frac > 0.0) ? elapsed * (1.0 / frac - 1.0) : 0.0;
-	const unsigned pc = (prog->len > 0)
-		? (unsigned)(prog->i * 100 / prog->len)
-		: 0;
-
-	log_emit(LOG_INFO, subsys ? subsys : LOG_SUBSYS, __FILE__, __LINE__,
-		"%s %zu/%zu (%u%%) elapsed %.2fs eta %.2fs", prog->unit,
-		prog->i, prog->len, pc, elapsed, eta);
 }
 
 int circ_values_init(struct circ_values *vals, size_t len)

--- a/phase2/circ.c
+++ b/phase2/circ.c
@@ -129,7 +129,8 @@ int circ_init(struct circ *ct, struct circ_hamil hm,
 		log_error("circ_init: qreg_init failed");
 		goto err_qreg_init;
 	}
-	if (circ_cache_init(ct->reg.qb_hi, ct->reg.qb_lo) < 0) {
+	ct->cache = circ_cache_init(ct->reg.qb_hi, ct->reg.qb_lo);
+	if (!ct->cache) {
 		log_error("circ_init: cache_init failed");
 		goto err_cache_init;
 	}
@@ -142,6 +143,7 @@ int circ_init(struct circ *ct, struct circ_hamil hm,
 
 	circ_values_free(&ct->vals);
 err_vals_init:
+	circ_cache_free(ct->cache);
 err_cache_init:
 	qreg_free(&ct->reg);
 err_qreg_init:
@@ -169,6 +171,8 @@ void circ_free(struct circ *ct)
 		data_coeff_matrix_free(&ct->cm);
 		break;
 	}
+	circ_cache_free(ct->cache);
+	ct->cache = nullptr;
 	qreg_free(&ct->reg);
 }
 
@@ -221,18 +225,18 @@ static int circ_step_generic(struct circ *ct, const struct circ_hamil *hm,
 		const double phi = omega * hm->terms[j].cf;
 		const struct paulis code = hm->terms[j].op;
 
-		if (circ_cache_insert(code, phi) == 0)
+		if (circ_cache_insert(ct->cache, code, phi) == 0)
 			continue;
 
 		log_trace("paulirot, term: %zu, num_codes: %zu", i,
-			circ_cache_len());
-		circ_cache_flush(circ_flush, &ct->reg);
-		if (circ_cache_insert(code, phi) < 0)
+			circ_cache_len(ct->cache));
+		circ_cache_flush(ct->cache, circ_flush, &ct->reg);
+		if (circ_cache_insert(ct->cache, code, phi) < 0)
 			return -1;
 	}
-	log_trace(
-		"paulirot, last term group, num_codes: %zu", circ_cache_len());
-	circ_cache_flush(circ_flush, &ct->reg);
+	log_trace("paulirot, last term group, num_codes: %zu",
+		circ_cache_len(ct->cache));
+	circ_cache_flush(ct->cache, circ_flush, &ct->reg);
 
 	return 0;
 }

--- a/phase2/circ_cache.c
+++ b/phase2/circ_cache.c
@@ -12,6 +12,11 @@
  * is full (CACHE_MAX = 1024 terms), the caller must flush
  * the cache (triggering the MPI exchange and rotations) and
  * then re-insert.  Overflow returns -1 to signal this.
+ *
+ * Each cache is its own instance (no file-static state),
+ * so a process can hold several active circ contexts in
+ * parallel -- useful for Python plugins and multi-circuit
+ * drivers.
  */
 #define LOG_SUBSYS "cache"
 
@@ -24,54 +29,65 @@
 
 #define CACHE_MAX UINT64_C(0x0400)
 
-static int qb_hi, qb_lo;
-static struct paulis pa_hi, pa_lo[CACHE_MAX];
-static double phis[CACHE_MAX];
-static size_t ch_len;
+struct circ_cache {
+	int qb_hi, qb_lo;
+	struct paulis pa_hi;
+	struct paulis pa_lo[CACHE_MAX];
+	double phis[CACHE_MAX];
+	size_t ch_len;
+};
 
-int circ_cache_init(int hi, int lo)
+struct circ_cache *circ_cache_init(int hi, int lo)
 {
-	qb_hi = hi;
-	qb_lo = lo;
-	ch_len = 0;
-
-	return 0;
+	struct circ_cache *c = calloc(1, sizeof *c);
+	if (!c)
+		return nullptr;
+	c->qb_hi = hi;
+	c->qb_lo = lo;
+	return c;
 }
 
-int circ_cache_insert(struct paulis pa, double phi)
+void circ_cache_free(struct circ_cache *c)
+{
+	free(c);
+}
+
+int circ_cache_insert(struct circ_cache *c,
+	struct paulis pa, double phi)
 {
 	struct paulis lo, hi;
-	paulis_split(pa, qb_lo, qb_hi, &lo, &hi);
-	if (ch_len == 0) {
-		pa_hi = hi;
-		pa_lo[0] = lo;
-		phis[0] = phi;
-		ch_len = 1;
+	paulis_split(pa, c->qb_lo, c->qb_hi, &lo, &hi);
+	if (c->ch_len == 0) {
+		c->pa_hi = hi;
+		c->pa_lo[0] = lo;
+		c->phis[0] = phi;
+		c->ch_len = 1;
 		return 0;
 	}
 
-	if (ch_len < CACHE_MAX && paulis_eq(pa_hi, hi)) {
-		const size_t k = ch_len++;
-		pa_lo[k] = lo;
-		phis[k] = phi;
+	if (c->ch_len < CACHE_MAX && paulis_eq(c->pa_hi, hi)) {
+		const size_t k = c->ch_len++;
+		c->pa_lo[k] = lo;
+		c->phis[k] = phi;
 		return 0;
 	}
 
 	return -1;
 }
 
-void circ_cache_flush(circ_cache_op fn, void *data)
+void circ_cache_flush(struct circ_cache *c,
+	circ_cache_op fn, void *data)
 {
-	if (ch_len > 0 && fn) {
-		log_trace("flush: %zu terms (cache_max=%llu)", ch_len,
+	if (c->ch_len > 0 && fn) {
+		log_trace("flush: %zu terms (cache_max=%llu)", c->ch_len,
 			(unsigned long long)CACHE_MAX);
-		fn(pa_hi, pa_lo, phis, ch_len, data);
+		fn(c->pa_hi, c->pa_lo, c->phis, c->ch_len, data);
 	}
 
-	ch_len = 0;
+	c->ch_len = 0;
 }
 
-size_t circ_cache_len(void)
+size_t circ_cache_len(const struct circ_cache *c)
 {
-	return ch_len;
+	return c->ch_len;
 }

--- a/phase2/circ_cache.c
+++ b/phase2/circ_cache.c
@@ -76,7 +76,9 @@ int circ_cache_insert(struct circ_cache *c,
 }
 
 void circ_cache_flush(struct circ_cache *c,
-	circ_cache_op fn, void *data)
+	void (*fn)(struct paulis hi, const struct paulis *lo,
+		double *phis, size_t n, void *data),
+	void *data)
 {
 	if (c->ch_len > 0 && fn) {
 		log_trace("flush: %zu terms (cache_max=%llu)", c->ch_len,

--- a/phase2/circ_cache.h
+++ b/phase2/circ_cache.h
@@ -5,15 +5,39 @@
 
 #include "phase2/paulis.h"
 
-int circ_cache_init(int hi, int lo);
+/*
+ * Pauli-rotation batch cache.  An instance accumulates
+ * Hamiltonian terms that share a single hi-qubit Pauli
+ * code; flushing emits one MPI exchange + multi-rotation
+ * for all batched terms.
+ *
+ * The full struct definition lives in circ_cache.c;
+ * callers (currently only phase2/circ.c) hold an opaque
+ * pointer and go through the API below.
+ */
+struct circ_cache;
 
-int circ_cache_insert(struct paulis pa, double phi);
+/* Allocate a new cache for the given (hi, lo) qubit
+ * partition.  Returns NULL on allocation failure. */
+struct circ_cache *circ_cache_init(int hi, int lo);
+
+void circ_cache_free(struct circ_cache *c);
+
+/* Try to insert (pa, phi).  Returns 0 on success, -1 if
+ * the cache is full or `pa`'s hi-code differs from the
+ * current batch -- caller must flush then retry. */
+int circ_cache_insert(struct circ_cache *c,
+	struct paulis pa, double phi);
 
 typedef void (*circ_cache_op)(
 	struct paulis, const struct paulis *, double *, size_t, void *);
 
-void circ_cache_flush(circ_cache_op fn, void *data);
+/* Flush the cache: invoke fn with the accumulated hi
+ * code, lo codes, phis, and term count; then reset to
+ * empty.  Calling on an empty cache is a no-op. */
+void circ_cache_flush(struct circ_cache *c,
+	circ_cache_op fn, void *data);
 
-size_t circ_cache_len(void);
+size_t circ_cache_len(const struct circ_cache *c);
 
 #endif /* CIRC_CACHE */

--- a/phase2/circ_cache.h
+++ b/phase2/circ_cache.h
@@ -29,14 +29,14 @@ void circ_cache_free(struct circ_cache *c);
 int circ_cache_insert(struct circ_cache *c,
 	struct paulis pa, double phi);
 
-typedef void (*circ_cache_op)(
-	struct paulis, const struct paulis *, double *, size_t, void *);
-
 /* Flush the cache: invoke fn with the accumulated hi
- * code, lo codes, phis, and term count; then reset to
- * empty.  Calling on an empty cache is a no-op. */
+ * code, lo codes, phis, term count, and caller-supplied
+ * data; then reset to empty.  Calling on an empty cache
+ * is a no-op. */
 void circ_cache_flush(struct circ_cache *c,
-	circ_cache_op fn, void *data);
+	void (*fn)(struct paulis hi, const struct paulis *lo,
+		double *phis, size_t n, void *data),
+	void *data);
 
 size_t circ_cache_len(const struct circ_cache *c);
 

--- a/phase2/phase2_run.c
+++ b/phase2/phase2_run.c
@@ -136,7 +136,8 @@ int phase2_run(const char **pauli_strs,
 	qreg_zero(&reg);
 	qreg_setamp(&reg, idx, 1.0);
 
-	if (circ_cache_init(reg.qb_hi, reg.qb_lo) < 0)
+	struct circ_cache *cache = circ_cache_init(reg.qb_hi, reg.qb_lo);
+	if (!cache)
 		goto err_cache;
 
 	for (size_t k = 0; k < nterms; k++) {
@@ -146,25 +147,26 @@ int phase2_run(const char **pauli_strs,
 			goto err_pauli;
 
 		double phi = delta * coeffs[k];
-		if (circ_cache_insert(code, phi) != 0) {
-			circ_cache_flush(flush_cb, &reg);
-			if (circ_cache_insert(code, phi) < 0)
+		if (circ_cache_insert(cache, code, phi) != 0) {
+			circ_cache_flush(cache, flush_cb, &reg);
+			if (circ_cache_insert(cache, code, phi) < 0)
 				goto err_pauli;
 		}
 	}
-	circ_cache_flush(flush_cb, &reg);
+	circ_cache_flush(cache, flush_cb, &reg);
 
 	_Complex double z;
 	qreg_getamp(&reg, idx, &z);
 	*out_re = creal(z);
 	*out_im = cimag(z);
 
+	circ_cache_free(cache);
 	qreg_free(&reg);
 
 	return 0;
 
 err_pauli:
-	circ_cache_flush(nullptr, nullptr);
+	circ_cache_free(cache);
 err_cache:
 	qreg_free(&reg);
 

--- a/test/t-circ.c
+++ b/test/t-circ.c
@@ -118,22 +118,6 @@ static void t_muldet_init_free(void)
 	circ_muldet_free(&md);
 }
 
-static void t_prog(void)
-{
-	struct circ_prog prog;
-
-	circ_prog_init(&prog, 100, "step");
-	TEST_EQ(prog.len, (size_t)100);
-	TEST_EQ(prog.i, (size_t)0);
-	TEST_EQ(prog.pc, 0u);
-
-	for (size_t n = 0; n < 100; n++)
-		circ_prog_tick(&prog);
-
-	TEST_EQ(prog.i, (size_t)100);
-	TEST_EQ(prog.pc, 100u);
-}
-
 static void t_values_init_free(void)
 {
 	struct circ_values vals;
@@ -164,7 +148,6 @@ int main(void)
 	t_hamil_init_free();
 	t_hamil_sort_lex();
 	t_muldet_init_free();
-	t_prog();
 	t_values_init_free();
 
 	world_free();

--- a/test/t-circ_cache.c
+++ b/test/t-circ_cache.c
@@ -23,7 +23,13 @@ static struct world_info WD;
 #define SEED UINT64_C(0x334b06fc8c7b40ea)
 static struct xoshiro256ss RNG;
 
-void t_cache_00(void)
+/*
+ * Basic insert/flush/len semantics: an empty cache
+ * accepts a first code, accepts subsequent codes with
+ * the same hi part, rejects a different hi part with
+ * -1, and after flush is back to empty.
+ */
+void t_cache_basic(void)
 {
 	struct paulis p = paulis_new();
 
@@ -36,12 +42,48 @@ void t_cache_00(void)
 	TEST_ASSERT(circ_cache_insert(c, p, 0.1) == 0, "insert the same code");
 	TEST_ASSERT(circ_cache_len(c) == 2, "cache size should be 2");
 	paulis_set(&p, PAULI_X, 1);
-	TEST_ASSERT(circ_cache_insert(c, p, 0.0) < 1, "insert different code");
+	TEST_ASSERT(circ_cache_insert(c, p, 0.0) < 0, "insert different code");
 	TEST_ASSERT(circ_cache_len(c) == 2, "cache size should be 2");
 	circ_cache_flush(c, nullptr, nullptr);
 	TEST_ASSERT(circ_cache_len(c) == 0, "cache size should be 0");
-	TEST_ASSERT(circ_cache_insert(c, p, 0.0) == 0, "insert different code");
+	TEST_ASSERT(circ_cache_insert(c, p, 0.0) == 0,
+		"insert after flush should succeed");
 	TEST_ASSERT(circ_cache_len(c) == 1, "cache size should be 1");
+	circ_cache_free(c);
+}
+
+/*
+ * Boundary: CACHE_MAX inserts (all matching hi)
+ * succeed; the next insert returns -1; a flush
+ * empties the cache and the rejected insert
+ * succeeds.  The exact cap (1024) is private to
+ * circ_cache.c, so the test discovers it by
+ * pushing until the first -1.
+ */
+#define CACHE_MAX_EXPECTED 1024
+void t_cache_overflow(void)
+{
+	struct paulis p = paulis_new();
+	struct circ_cache *c = circ_cache_init(1, 1);
+	TEST_ASSERT(c, "can't init cache");
+
+	size_t inserted = 0;
+	while (circ_cache_insert(c, p, (double)inserted) == 0)
+		inserted++;
+	TEST_EQ(inserted, (size_t)CACHE_MAX_EXPECTED);
+	TEST_EQ(circ_cache_len(c), (size_t)CACHE_MAX_EXPECTED);
+
+	/* One more insert: refused. */
+	TEST_ASSERT(circ_cache_insert(c, p, -1.0) < 0,
+		"full cache must reject insert");
+	TEST_EQ(circ_cache_len(c), (size_t)CACHE_MAX_EXPECTED);
+
+	/* Flush -> empty -> next insert succeeds. */
+	circ_cache_flush(c, nullptr, nullptr);
+	TEST_EQ(circ_cache_len(c), (size_t)0);
+	TEST_ASSERT(circ_cache_insert(c, p, -1.0) == 0,
+		"insert after flush must succeed");
+
 	circ_cache_free(c);
 }
 
@@ -53,7 +95,8 @@ int main(void)
 
 	xoshiro256ss_init(&RNG, SEED);
 
-	t_cache_00();
+	t_cache_basic();
+	t_cache_overflow();
 
 	world_free();
 }

--- a/test/t-circ_cache.c
+++ b/test/t-circ_cache.c
@@ -27,19 +27,22 @@ void t_cache_00(void)
 {
 	struct paulis p = paulis_new();
 
-	TEST_ASSERT(circ_cache_init(1, 1) == 0, "can't init cache");
-	TEST_ASSERT(circ_cache_len() == 0, "init size must be zero");
-	TEST_ASSERT(circ_cache_insert(p, 0.0) == 0, "cannot insert first code");
-	TEST_ASSERT(circ_cache_len(), "cache size should be 1");
-	TEST_ASSERT(circ_cache_insert(p, 0.1) == 0, "insert the same code");
-	TEST_ASSERT(circ_cache_len() == 2, "cache size should be 2");
+	struct circ_cache *c = circ_cache_init(1, 1);
+	TEST_ASSERT(c, "can't init cache");
+	TEST_ASSERT(circ_cache_len(c) == 0, "init size must be zero");
+	TEST_ASSERT(circ_cache_insert(c, p, 0.0) == 0,
+		"cannot insert first code");
+	TEST_ASSERT(circ_cache_len(c), "cache size should be 1");
+	TEST_ASSERT(circ_cache_insert(c, p, 0.1) == 0, "insert the same code");
+	TEST_ASSERT(circ_cache_len(c) == 2, "cache size should be 2");
 	paulis_set(&p, PAULI_X, 1);
-	TEST_ASSERT(circ_cache_insert(p, 0.0) < 1, "insert different code");
-	TEST_ASSERT(circ_cache_len() == 2, "cache size should be 2");
-	circ_cache_flush(nullptr, nullptr);
-	TEST_ASSERT(circ_cache_len() == 0, "cache size should be 0");
-	TEST_ASSERT(circ_cache_insert(p, 0.0) == 0, "insert different code");
-	TEST_ASSERT(circ_cache_len() == 1, "cache size should be 1");
+	TEST_ASSERT(circ_cache_insert(c, p, 0.0) < 1, "insert different code");
+	TEST_ASSERT(circ_cache_len(c) == 2, "cache size should be 2");
+	circ_cache_flush(c, nullptr, nullptr);
+	TEST_ASSERT(circ_cache_len(c) == 0, "cache size should be 0");
+	TEST_ASSERT(circ_cache_insert(c, p, 0.0) == 0, "insert different code");
+	TEST_ASSERT(circ_cache_len(c) == 1, "cache size should be 1");
+	circ_cache_free(c);
 }
 
 int main(void)

--- a/test/t-circ_trott.c
+++ b/test/t-circ_trott.c
@@ -164,7 +164,8 @@ static void t_circ_trott(size_t tag, size_t ts, size_t md, size_t ht)
 	struct trott tt = { 0 };
 	tt.ct.stprep_kind = STPREP_MULTIDET;
 	qreg_init(&tt.ct.reg, NUM_QUBITS);
-	circ_cache_init(tt.ct.reg.qb_hi, tt.ct.reg.qb_lo);
+	tt.ct.cache = circ_cache_init(tt.ct.reg.qb_hi, tt.ct.reg.qb_lo);
+	TEST_ASSERT(tt.ct.cache != nullptr, "cache init failed");
 	tt.dt.delta = HAMIL_DELTA;
 
 	struct circ_hamil *h = &tt.ct.hm;
@@ -211,12 +212,14 @@ static void t_circ_trott(size_t tag, size_t ts, size_t md, size_t ht)
 			creal(TROTT_VALS[s]), cimag(TROTT_VALS[s]));
 	}
 
-	// free(res.steps);  -- freed by circ_destroy()
+	free(tt.ct.vals.z);
 malloc_ressteps:
 	free(m->dets);
 malloc_mddets:
 	free(h->terms);
-malloc_hterms:;
+malloc_hterms:
+	circ_cache_free(tt.ct.cache);
+	qreg_free(&tt.ct.reg);
 }
 
 int main(void)

--- a/test/t-circ_trott2.c
+++ b/test/t-circ_trott2.c
@@ -174,7 +174,8 @@ static void t_circ_trott2(size_t tag, size_t ts, size_t md, size_t ht)
 	struct trott2 t2 = { 0 };
 	t2.ct.stprep_kind = STPREP_MULTIDET;
 	qreg_init(&t2.ct.reg, NUM_QUBITS);
-	circ_cache_init(t2.ct.reg.qb_hi, t2.ct.reg.qb_lo);
+	t2.ct.cache = circ_cache_init(t2.ct.reg.qb_hi, t2.ct.reg.qb_lo);
+	TEST_ASSERT(t2.ct.cache != nullptr, "cache init failed");
 	t2.dt.delta = HAMIL_DELTA;
 
 	struct circ_hamil *h = &t2.ct.hm;
@@ -224,7 +225,9 @@ malloc_ressteps:
 	free(m->dets);
 malloc_mddets:
 	free(h->terms);
-malloc_hterms:;
+malloc_hterms:
+	circ_cache_free(t2.ct.cache);
+	qreg_free(&t2.ct.reg);
 }
 
 int main(void)


### PR DESCRIPTION
Audit circ + circ_cache.  Six commits.


## Drop circ_prog; ph2run owns progress

`struct circ_prog` and the three `circ_prog_*`
functions (~40 LOC of timer + ETA + log code)
carried no circuit-specific knowledge -- the
algorithms called them only to emit a per-step
status line.  The existing `struct phase2_step_writer`
already gives ph2run a per-step hook with the step
index; extending its context to also track `total`
and `t0` lets ph2run emit the progress line
alongside its existing HDF5 write.  circ becomes
pure compute.

Removed `struct circ_prog`, the three function
prototypes, the prog impl in `phase2/circ.c`, the
four `circ_prog_*` call sites in
`circ/{trott,trott2,qdrift,cmpsit}.c`, and the
`t_prog` unit test.  Added `struct step_ctx` and
the per-percent emit logic in `ph2run/ph2run.c`'s
`step_thunk`.


## circ_cache: instance-based state

`circ_cache` held all its state in file-scope
statics, meaning the process could carry at most
one active circ context.  Python plugins, multi-
circuit drivers, and any future caller wanting two
`struct circ` simultaneously had no way to share
the address space.

State now lives in a heap-allocated `struct
circ_cache`.  `circ_cache_init` returns a pointer
(NULL on failure); new `circ_cache_free` releases
it; `insert / flush / len` take the instance as
first argument.  `struct circ`'s pre-existing
`cache` pointer member is allocated by `circ_init`,
freed by `circ_free`.  `phase2_run.c` (the Python
ctypes entry point) gets its own local cache
instance.  The two tests that opened a circ
manually (`t-circ_trott`, `t-circ_trott2`)
allocate and free the cache alongside the qreg.

Invisible to phase2's public consumers: the public
header doesn't mention `circ_cache`.


## API tightness

Small surface fixes:

  - `circ_hamil_free` / `circ_muldet_free` /
    `circ_values_free`: drop redundant
    `if (ptr != nullptr)` (free(NULL) is safe);
    zero out the buffer pointer and the length
    field after free so a double-free is a clean
    no-op.
  - Drop spurious `const` on by-value parameters
    (`sp_kind`, `vals_len`, `omega`,
    `n_sites`/`n_alpha`/`n_beta`, `weight`,
    `tapered`).  The qualifier doesn't reach
    callers; it was noise.
  - Drop the `circ_cache_op` typedef.  Spell out
    the function-pointer type in
    `circ_cache_flush`'s parameter list.
    Linux-style: typedef'd function pointers hide
    the pointer-ness and break the `grep
    *fn` invariant.  Single caller (`circ_flush`
    in `phase2/circ.c`) is unchanged.


## Tests

`t-circ_cache` previously covered basic
insert/flush/mismatch only.  New
`t_cache_overflow`: insert until the first -1
(probes the CACHE_MAX = 1024 ceiling), verify
count, confirm full cache rejects further
inserts, flush, confirm the previously rejected
insert now succeeds.


## Documentation

`include/phase2/circ.h` and `phase2/circ.c` lacked
top-of-file headers and per-function contract
blocks.  Added:

  - Top-of-file header in `circ.h` summarising what
    each section defines (carriers, state-prep
    enum, coeff-matrix payloads, lifecycle, public
    function surface).
  - Per-field annotations on `struct circ_hamil`,
    `struct circ_muldet`, `struct circ_values`,
    `struct circ`.
  - Contract blocks on every public function that
    lacked one: hamil / muldet / values init and
    free helpers, sort_lex, prepst, step,
    step_reverse, measure.  Each block names
    preconditions, ownership, error behaviour, and
    the sentinel for `circ_measure`.
  - Top-of-file header in `circ.c` mapping its
    sections and pointing at `circ_cache` (private
    header) and the algorithm drivers in `circ/`.
  - `doc/phase2.md` §3.4 (Cache Batching) and
    §3.6 (Step-writer callback) refreshed: cache
    is now an instance type; ph2run owns
    progress telemetry behind the step-writer
    callback.


## Deferred (explicit non-goals)

  - `circ_step_generic` reverse-walk split: 2-line
    conditional inside a clear 25-line function;
    refactor would fragment without measurable
    gain.
  - `circ_measure` fn-ptr dispatch: cold path
    (once per Trotter step).  Premature
    optimisation.
  - Renaming `data_coeff_matrix_free` to
    `circ_coeff_matrix_free`: the `data_` pair
    (`_load` in ph2run, `_free` in circ) is by
    design.
  - Extract progress emitter to a generic
    utility: per direction, telemetry lives in
    ph2run now.  Revisit if a second emitter
    shows up.


## Test plan

  - `make clean && make -j$(nproc) all` -- clean
    parallel scratch build.
  - `make check` -- 31/31 OK.
  - `make check-mpi MPIRANKS=2` -- 30/30 OK.
  - `make check-slow` -- 1/1 OK.
  - `make check-circ` -- all 7 t-circ* tests pass
    (existing set + new overflow scenario in
    t-circ_cache).
  - Manual: `mpirun -n 2 ./build/ph2run/ph2run -S
    test/data/H2O_CAS56.h5 trott -D 0.1 -s 4` --
    progress lines appear at percent boundaries,
    same shape as before (`step 1/4 (25%) elapsed
    ... eta ...`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
