### PR TITLE
paulis: enum end-to-end, share host+device core, docs, tests

### DIFF
--- a/bench/b-paulis.c
+++ b/bench/b-paulis.c
@@ -20,14 +20,14 @@ static struct xoshiro256ss RNG;
 
 #define WIDTH_MAX (64)
 
-static int rand_pauli(void)
+static enum pauli_op rand_pauli(void)
 {
-	return (int)(xoshiro256ss_next(&RNG) % 4);
+	return (enum pauli_op)(xoshiro256ss_next(&RNG) % 4);
 }
 
 struct b_paulis_set {
 	struct paulis *p;
-	int op;
+	enum pauli_op op;
 	uint32_t n;
 };
 

--- a/bench/b-qreg.c
+++ b/bench/b-qreg.c
@@ -25,9 +25,9 @@ static struct world_info WD;
 #define SEED UINT64_C(0x2d1da81dc94cf64f)
 static struct xoshiro256ss RNG;
 
-static int rand_pauli(void)
+static enum pauli_op rand_pauli(void)
 {
-	return (int)(xoshiro256ss_next(&RNG) % 4);
+	return (enum pauli_op)(xoshiro256ss_next(&RNG) % 4);
 }
 
 struct b_qreg_init {

--- a/include/phase2/paulis.h
+++ b/include/phase2/paulis.h
@@ -143,6 +143,8 @@ PAULIS_HD static inline uint64_t paulis_effect_raw(struct paulis code,
 	return i ^ code.pak[0];
 }
 
+#undef PAULIS_HD
+
 /*
  * Split `code` into two disjoint qubit ranges:
  *

--- a/include/phase2/paulis.h
+++ b/include/phase2/paulis.h
@@ -3,19 +3,12 @@
 
 #include <stdint.h>
 
-#if PHASE2_BACKEND == 1 /* QuEST */
-#include "QuEST.h"
-#else
-/* QuEST defines these as enum pauliOpType.
- * To avoid the clash, we pass ints to functions, instead of the enum.
- */
-enum {
+enum pauli_op {
 	PAULI_I = 0,
 	PAULI_X = 1,
 	PAULI_Y = 2,
 	PAULI_Z = 3,
 };
-#endif /* PHASE2_BACKEND == 1 */
 
 struct paulis {
 	uint64_t pak[2];
@@ -23,9 +16,9 @@ struct paulis {
 
 struct paulis paulis_new(void);
 
-int paulis_get(struct paulis code, uint32_t n);
+enum pauli_op paulis_get(struct paulis code, uint32_t n);
 
-void paulis_set(struct paulis *code, int op, uint32_t n);
+void paulis_set(struct paulis *code, enum pauli_op op, uint32_t n);
 
 int paulis_eq(struct paulis code1, struct paulis code2);
 

--- a/include/phase2/paulis.h
+++ b/include/phase2/paulis.h
@@ -31,9 +31,6 @@ uint64_t paulis_effect(struct paulis code, uint64_t i, _Complex double *z);
 void paulis_split(struct paulis code, uint32_t qb_lo, uint32_t qb_hi,
 	struct paulis *lo, struct paulis *hi);
 
-void paulis_merge(struct paulis *code, uint32_t qb_lo, uint32_t qb_hi,
-	struct paulis lo, struct paulis hi);
-
 /* Lexicographical order */
 int paulis_cmp(struct paulis a, struct paulis b);
 

--- a/include/phase2/paulis.h
+++ b/include/phase2/paulis.h
@@ -1,8 +1,39 @@
 #ifndef PAULIS_H
 #define PAULIS_H
 
+/*
+ * phase2/paulis.h -- bit-packed Pauli-string
+ * encoding and the operations on it.
+ *
+ * A Pauli string acts on up to QREG_MAX_WIDTH = 64
+ * qubits, with one Pauli operator (I, X, Y, or Z)
+ * per qubit.  Each string is stored in two 64-bit
+ * words using the standard symplectic
+ * representation (see paulis.c for the derivation):
+ *
+ *     pak[0]  =  flip bits   (X / Y components)
+ *     pak[1]  =  phase bits  (Z / Y components)
+ *
+ * Qubit n is at bit n of each word.  The per-qubit
+ * code is read off via paulis_get / set:
+ *
+ *     I = 00,  X = 10,  Z = 01,  Y = 11
+ *
+ * All public operations take qubit indices in
+ * [0, 64); higher indices are undefined (the shift
+ * `<< n` would wrap).  The struct itself is 16
+ * bytes and cheap to pass by value -- nearly every
+ * function does.
+ */
+
 #include <stdint.h>
 
+/*
+ * Single-qubit Pauli operators.  Integer values
+ * are stable and form part of the public API;
+ * paulis_set encodes them into the symplectic form
+ * via a switch, paulis_get inverts.
+ */
 enum pauli_op {
 	PAULI_I = 0,
 	PAULI_X = 1,
@@ -10,28 +41,94 @@ enum pauli_op {
 	PAULI_Z = 3,
 };
 
+/*
+ * Bit-packed n-qubit Pauli string.
+ *
+ *   pak[0]   flip / X-component bits; bit n encodes
+ *            qubit n.
+ *   pak[1]   phase / Z-component bits; bit n encodes
+ *            qubit n.
+ *
+ * (pak[0]:n, pak[1]:n) read off as (I, X, Z, Y) for
+ * (00, 10, 01, 11) respectively.  Default-zero
+ * initialiser is the all-identity string.
+ */
 struct paulis {
 	uint64_t pak[2];
 };
 
+/* Return the all-identity Pauli string. */
 struct paulis paulis_new(void);
 
+/*
+ * Decode the Pauli operator at qubit n
+ * (0 <= n < 64).  Returns one of PAULI_{I,X,Y,Z}.
+ */
 enum pauli_op paulis_get(struct paulis code, uint32_t n);
 
+/*
+ * Encode the Pauli operator at qubit n
+ * (0 <= n < 64).  Replaces whatever was there
+ * before; bits at other qubits are preserved.
+ * `op` must be one of PAULI_{I,X,Y,Z} -- any other
+ * value leaves the string unchanged.
+ */
 void paulis_set(struct paulis *code, enum pauli_op op, uint32_t n);
 
+/*
+ * Bitwise equality of two Pauli strings.  Returns
+ * 1 if every qubit's Pauli is the same, 0
+ * otherwise.
+ */
 int paulis_eq(struct paulis code1, struct paulis code2);
 
+/*
+ * Shift the encoded Pauli string n positions
+ * towards higher / lower qubit indices.  Bits
+ * shifted out are dropped (undefined-behaviour
+ * free for n in [0, 64)).  No bounds checking on
+ * the resulting effective qubit count -- callers
+ * that mix shift and split must track the active
+ * range themselves.
+ */
 void paulis_shl(struct paulis *code, uint32_t n);
-
 void paulis_shr(struct paulis *code, uint32_t n);
 
+/*
+ * Apply the Pauli string to computational basis
+ * state |i>: P|i> = z * |j>, returning j and
+ * multiplying *z by the phase factor.
+ *
+ * `z` may be NULL, in which case the phase is not
+ * computed and only the flipped index j is
+ * returned.  The cold path: callers that need only
+ * the partner index (e.g. qreg_paulirot_hi
+ * computing the partner MPI rank) pass NULL to
+ * skip two popcounts and a branch.
+ */
 uint64_t paulis_effect(struct paulis code, uint64_t i, _Complex double *z);
 
+/*
+ * Split `code` into two disjoint qubit ranges:
+ *
+ *   *lo  carries qubits [0, qb_lo).
+ *   *hi  carries qubits [qb_lo, qb_lo + qb_hi).
+ *
+ * Bits outside those two ranges are zeroed in the
+ * outputs.  Used by the rotation cache to separate
+ * MPI-distributed hi qubits from local lo qubits.
+ * Inputs and outputs may not alias.
+ */
 void paulis_split(struct paulis code, uint32_t qb_lo, uint32_t qb_hi,
 	struct paulis *lo, struct paulis *hi);
 
-/* Lexicographical order */
+/*
+ * Lexicographic total order on Pauli strings,
+ * highest qubit first.  Returns -1, 0, or +1.  Used
+ * by circ_hamil_sort_lex to group Hamiltonian
+ * terms with matching hi-qubit codes contiguously,
+ * which maximises the batch-cache hit rate.
+ */
 int paulis_cmp(struct paulis a, struct paulis b);
 
 #endif /* PAULIS_H */

--- a/include/phase2/paulis.h
+++ b/include/phase2/paulis.h
@@ -109,6 +109,41 @@ void paulis_shr(struct paulis *code, uint32_t n);
 uint64_t paulis_effect(struct paulis code, uint64_t i, _Complex double *z);
 
 /*
+ * Integer core of paulis_effect, shared between the
+ * host implementation (phase2/paulis.c) and the
+ * CUDA device kernel (phase2/qreg_cuda_lo.cu).
+ *
+ * Returns j = i XOR pak[0] (the flipped basis-state
+ * index) and writes the phase exponent r4 in
+ * [0, 4) to *r4_out: the amplitude on |j> picks up
+ * a factor of (i)^r4_out, where i is the imaginary
+ * unit.  The caller does the complex multiply in
+ * its own complex type (host uses _Complex double,
+ * device uses cuDoubleComplex).
+ *
+ * Any change to the phase formula belongs here and
+ * here only -- the host and device wrappers both
+ * read r4_out and translate.
+ *
+ * `__host__ __device__` under nvcc; plain inline
+ * otherwise.
+ */
+#ifdef __CUDACC__
+#  define PAULIS_HD __host__ __device__
+#else
+#  define PAULIS_HD
+#endif
+
+PAULIS_HD static inline uint64_t paulis_effect_raw(struct paulis code,
+	uint64_t i, int *r4_out)
+{
+	const int mi = __builtin_popcountll(i & code.pak[1]);
+	const int is = __builtin_popcountll(code.pak[0] & code.pak[1]);
+	*r4_out = (is + 2 * mi) & 0x3;
+	return i ^ code.pak[0];
+}
+
+/*
  * Split `code` into two disjoint qubit ranges:
  *
  *   *lo  carries qubits [0, qb_lo).

--- a/phase2/paulis.c
+++ b/phase2/paulis.c
@@ -158,6 +158,10 @@ rt:
 void paulis_split(struct paulis code, uint32_t qb_lo, uint32_t qb_hi,
 	struct paulis *lo, struct paulis *hi)
 {
+	/* mask_lo covers bits [0, qb_lo); mask_hi
+	 * covers bits [qb_lo, qb_lo + qb_hi).  Bits
+	 * outside that combined range fall through to
+	 * neither output. */
 	const uint64_t mask_lo = (UINT64_C(1) << qb_lo) - 1;
 	const uint64_t mask_hi = (UINT64_C(1) << (qb_hi + qb_lo)) - 1 - mask_lo;
 
@@ -168,6 +172,14 @@ void paulis_split(struct paulis code, uint32_t qb_lo, uint32_t qb_hi,
 	hi->pak[1] = code.pak[1] & mask_hi;
 }
 
+/*
+ * paulis_cmp - lexicographic order, highest qubit
+ * first.  The early-out via paulis_eq lets the
+ * common "same hi-code" check in the batch cache
+ * skip the per-qubit loop.  The loop reads qubits
+ * MSB-to-LSB so the resulting order matches the
+ * bit-string read top-down.
+ */
 int paulis_cmp(struct paulis a, struct paulis b)
 {
 	if (paulis_eq(a, b))

--- a/phase2/paulis.c
+++ b/phase2/paulis.c
@@ -32,7 +32,7 @@ inline struct paulis paulis_new(void)
  * This is the standard "symplectic" representation used in
  * stabiliser / Pauli-group literature.
  */
-void paulis_set(struct paulis *code, const int op, const uint32_t n)
+void paulis_set(struct paulis *code, enum pauli_op op, uint32_t n)
 {
 	const uint64_t n_mask = UINT64_C(1) << n;
 
@@ -69,9 +69,9 @@ void paulis_set(struct paulis *code, const int op, const uint32_t n)
  * which reads as the integer 2 — easily mistaken for Y if
  * one assumes a naive I/X/Y/Z = 0/1/2/3 encoding.
  */
-int paulis_get(const struct paulis code, const uint32_t n)
+enum pauli_op paulis_get(struct paulis code, uint32_t n)
 {
-	int pa = (code.pak[0] >> n & 1) | ((code.pak[1] >> n & 1) << 1);
+	const int pa = (code.pak[0] >> n & 1) | ((code.pak[1] >> n & 1) << 1);
 
 	switch (pa) {
 	case 0:
@@ -189,8 +189,8 @@ int paulis_cmp(struct paulis a, struct paulis b)
 		return 0;
 
 	for (uint32_t n = 0; n < QREG_MAX_WIDTH; n++) {
-		const int x = paulis_get(a, QREG_MAX_WIDTH - n - 1);
-		const int y = paulis_get(b, QREG_MAX_WIDTH - n - 1);
+		const enum pauli_op x = paulis_get(a, QREG_MAX_WIDTH - n - 1);
+		const enum pauli_op y = paulis_get(b, QREG_MAX_WIDTH - n - 1);
 		if (x < y)
 			return -1;
 		if (x > y)

--- a/phase2/paulis.c
+++ b/phase2/paulis.c
@@ -136,9 +136,28 @@ uint64_t paulis_effect(struct paulis code, uint64_t i, _Complex double *z)
 {
 	int r4;
 	const uint64_t j = paulis_effect_raw(code, i, &r4);
-	if (z) {
-		static const _Complex double phase[4] = { 1.0, I, -1.0, -I };
-		*z *= phase[r4];
+	if (!z)
+		return j;
+
+	/* Switch (not a table indexed by r4) so the case-0
+	 * path skips the complex multiply entirely.  The
+	 * device kernel uses the table form: GPU warps
+	 * prefer the uniform load over a switch that would
+	 * diverge across threads. */
+	switch (r4) {
+	case 0:
+		break;
+	case 1:
+		*z *= I;
+		break;
+	case 2:
+		*z *= -1.0;
+		break;
+	case 3:
+		*z *= -I;
+		break;
+	default:
+		unreachable();
 	}
 	return j;
 }

--- a/phase2/paulis.c
+++ b/phase2/paulis.c
@@ -87,18 +87,18 @@ enum pauli_op paulis_get(struct paulis code, uint32_t n)
 	}
 }
 
-inline int paulis_eq(const struct paulis code1, const struct paulis code2)
+inline int paulis_eq(struct paulis code1, struct paulis code2)
 {
 	return code1.pak[0] == code2.pak[0] && code1.pak[1] == code2.pak[1];
 }
 
-inline void paulis_shl(struct paulis *code, const uint32_t n)
+inline void paulis_shl(struct paulis *code, uint32_t n)
 {
 	code->pak[0] <<= n;
 	code->pak[1] <<= n;
 }
 
-inline void paulis_shr(struct paulis *code, const uint32_t n)
+inline void paulis_shr(struct paulis *code, uint32_t n)
 {
 	code->pak[0] >>= n;
 	code->pak[1] >>= n;
@@ -127,8 +127,7 @@ inline void paulis_shr(struct paulis *code, const uint32_t n)
  *   Total phase = i^is * (-1)^mi = i^(is + 2*mi).
  *   Reduce mod 4 to index into {1, i, -1, -i}.
  */
-uint64_t paulis_effect(
-	const struct paulis code, const uint64_t i, _Complex double *z)
+uint64_t paulis_effect(struct paulis code, uint64_t i, _Complex double *z)
 {
 	if (!z)
 		goto rt;
@@ -156,31 +155,17 @@ rt:
 	return i ^ code.pak[0];
 }
 
-void paulis_split(const struct paulis code, const uint32_t qb_lo,
-	const uint32_t qb_hi, struct paulis *lo, struct paulis *hi)
+void paulis_split(struct paulis code, uint32_t qb_lo, uint32_t qb_hi,
+	struct paulis *lo, struct paulis *hi)
 {
-	uint64_t mask_lo, mask_hi;
-
-	mask_lo = (UINT64_C(1) << qb_lo) - 1;
-	mask_hi = (UINT64_C(1) << (qb_hi + qb_lo)) - 1 - mask_lo;
+	const uint64_t mask_lo = (UINT64_C(1) << qb_lo) - 1;
+	const uint64_t mask_hi = (UINT64_C(1) << (qb_hi + qb_lo)) - 1 - mask_lo;
 
 	lo->pak[0] = code.pak[0] & mask_lo;
 	lo->pak[1] = code.pak[1] & mask_lo;
 
 	hi->pak[0] = code.pak[0] & mask_hi;
 	hi->pak[1] = code.pak[1] & mask_hi;
-}
-
-void paulis_merge(struct paulis *code, const uint32_t qb_lo,
-	const uint32_t qb_hi, const struct paulis lo, const struct paulis hi)
-{
-	uint64_t mask_lo, mask_hi;
-
-	mask_lo = (UINT64_C(1) << qb_lo) - 1;
-	mask_hi = (UINT64_C(1) << (qb_hi + qb_lo)) - 1 - mask_lo;
-
-	code->pak[0] = (lo.pak[0] & mask_lo) | (hi.pak[0] & mask_hi);
-	code->pak[1] = (lo.pak[1] & mask_lo) | (hi.pak[1] & mask_hi);
 }
 
 int paulis_cmp(struct paulis a, struct paulis b)

--- a/phase2/paulis.c
+++ b/phase2/paulis.c
@@ -126,33 +126,21 @@ inline void paulis_shr(struct paulis *code, uint32_t n)
  *
  *   Total phase = i^is * (-1)^mi = i^(is + 2*mi).
  *   Reduce mod 4 to index into {1, i, -1, -i}.
+ *
+ * Thin wrapper around paulis_effect_raw (paulis.h),
+ * which is the integer core shared with the CUDA
+ * device kernel.  Only the _Complex double multiply
+ * lives here.
  */
 uint64_t paulis_effect(struct paulis code, uint64_t i, _Complex double *z)
 {
-	if (!z)
-		goto rt;
-
-	const int mi = stdc_count_ones_ul(i & code.pak[1]);
-	const int is = stdc_count_ones_ul(code.pak[0] & code.pak[1]);
-	const int r4 = (is + 2 * mi) & 0x3;
-	switch (r4) {
-	case 0:
-		break;
-	case 1:
-		*z *= I;
-		break;
-	case 2:
-		*z *= -1.0;
-		break;
-	case 3:
-		*z *= -I;
-		break;
-	default:
-		unreachable();
+	int r4;
+	const uint64_t j = paulis_effect_raw(code, i, &r4);
+	if (z) {
+		static const _Complex double phase[4] = { 1.0, I, -1.0, -I };
+		*z *= phase[r4];
 	}
-
-rt:
-	return i ^ code.pak[0];
+	return j;
 }
 
 void paulis_split(struct paulis code, uint32_t qb_lo, uint32_t qb_hi,

--- a/phase2/phase2_run.c
+++ b/phase2/phase2_run.c
@@ -71,7 +71,7 @@ static int parse_pauli(const char *s, uint32_t nqb, struct paulis *out)
 
 	char *tok = strtok(buf, " \t\n");
 	while (tok) {
-		int op;
+		enum pauli_op op;
 		switch (tok[0]) {
 		case 'I':
 			op = PAULI_I;

--- a/phase2/qreg_cuda_lo.cu
+++ b/phase2/qreg_cuda_lo.cu
@@ -36,44 +36,17 @@ __global__ void kernelMix(cuDoubleComplex *__restrict__ a,
 }
 
 /*
- * paulisEffect - device reimplementation of paulis_effect.
- *
- * Uses __popcll (hardware population count for 64-bit) in
- * place of stdc_count_ones_ul.  Caller must ensure z != NULL.
- * See paulis.c:paulis_effect for the mathematical derivation.
- */
-__device__ uint64_t paulisEffect(
-	const struct paulis code, const uint64_t i, cuDoubleComplex *z)
-{
-	int mi = __popcll(i & code.pak[1]); // no. of minuses
-	int is = __popcll(code.pak[0] & code.pak[1]); // no. of i's
-	int r4 = (is + 2 * mi) & 0x3; // 4th root of unity
-	switch (r4) {
-	case 0:
-		break;
-	case 1:
-		*z = cuCmul(*z, (cuDoubleComplex){ .x = 0.0, .y = 1.0 });
-		break;
-	case 2:
-		*z = cuCmul(*z, (cuDoubleComplex){ .x = -1.0, .y = 0.0 });
-		break;
-	case 3:
-		*z = cuCmul(*z, (cuDoubleComplex){ .x = 0.0, .y = -1.0 });
-		break;
-	default:
-		unreachable();
-	}
-
-	return i ^ code.pak[0];
-}
-
-/*
  * kernelPauliRot - GPU equivalent of kernel_rot (qreg_qreg.c).
  *
  * One thread per amplitude index.  Same j < i guard: each
  * coupled pair (i, j) is processed by the thread with the
  * smaller index only, avoiding write conflicts without
  * atomics or synchronisation.
+ *
+ * The popcount + phase-exponent computation comes from
+ * paulis_effect_raw (paulis.h), which is shared with the
+ * host paulis_effect implementation.  Only the
+ * cuDoubleComplex multiply lives here.
  */
 __global__ void kernelPauliRot(
 	cuDoubleComplex *a, size_t n, struct paulis code, double c, double s)
@@ -82,10 +55,18 @@ __global__ void kernelPauliRot(
 	if (i >= n)
 		return;
 
-	cuDoubleComplex z = { .x = 1.0, .y = 0.0 };
-	const uint64_t j = paulisEffect(code, i, &z);
+	int r4;
+	const uint64_t j = paulis_effect_raw(code, i, &r4);
 	if (j < i)
 		return;
+
+	const cuDoubleComplex phase[4] = {
+		{ .x = 1.0, .y = 0.0 },
+		{ .x = 0.0, .y = 1.0 },
+		{ .x = -1.0, .y = 0.0 },
+		{ .x = 0.0, .y = -1.0 },
+	};
+	const cuDoubleComplex z = phase[r4];
 
 	const cuDoubleComplex zi = a[i];
 	const cuDoubleComplex zj = a[j];

--- a/test/t-circ.c
+++ b/test/t-circ.c
@@ -86,9 +86,9 @@ static void t_hamil_sort_lex(void)
 
 		/* Reconstruct which original term this is by
 		 * checking the Pauli string. */
-		int p0 = paulis_get(op, 0);
-		int p1 = paulis_get(op, 1);
-		int p3 = paulis_get(op, 3);
+		enum pauli_op p0 = paulis_get(op, 0);
+		enum pauli_op p1 = paulis_get(op, 1);
+		enum pauli_op p3 = paulis_get(op, 3);
 
 		if (p0 == PAULI_X && p1 == PAULI_Z)
 			TEST_EQ(cf, 10.0);

--- a/test/t-circ_trott.c
+++ b/test/t-circ_trott.c
@@ -22,8 +22,6 @@ static struct world_info WD;
 
 #if PHASE2_BACKEND == 0
 #define MARGIN (1.0e-14)
-#elif PHASE2_BACKEND == 1 /* QuEST */
-#define MARGIN (1.0e-6)
 #elif PHASE2_BACKEND == 2 /* cuQuantum */
 #define MARGIN (1.0e-14)
 #endif /* PHASE2_BACKEND */

--- a/test/t-circ_trott2.c
+++ b/test/t-circ_trott2.c
@@ -22,8 +22,6 @@ static struct world_info WD;
 
 #if PHASE2_BACKEND == 0
 #define MARGIN (1.0e-14)
-#elif PHASE2_BACKEND == 1 /* QuEST */
-#define MARGIN (1.0e-6)
 #elif PHASE2_BACKEND == 2 /* cuQuantum */
 #define MARGIN (1.0e-14)
 #endif /* PHASE2_BACKEND */

--- a/test/t-paulis.c
+++ b/test/t-paulis.c
@@ -341,6 +341,89 @@ static void t_paulis_cmp_02_eq(size_t tag)
 	TEST_ASSERT(res == exp, "[%zu] res=%d, exp=%d", tag, res, exp);
 }
 
+/*
+ * Top-bit boundary: paulis_set / paulis_get and the
+ * shift helpers must work at qubit 63 (the highest
+ * bit of the 64-bit word).  Off-by-one in the mask
+ * (e.g. `<< n` when n == 63 vs n == 64) would
+ * silently wrap.
+ */
+static void t_paulis_n63(void)
+{
+	const enum pauli_op ops[] = { PAULI_I, PAULI_X, PAULI_Y, PAULI_Z };
+
+	for (size_t k = 0; k < 4; k++) {
+		struct paulis ps = paulis_new();
+		paulis_set(&ps, ops[k], 63);
+		TEST_EQ(paulis_get(ps, 63), ops[k]);
+
+		/* Every other qubit must stay I. */
+		for (uint32_t n = 0; n < 63; n++)
+			TEST_EQ(paulis_get(ps, n), PAULI_I);
+	}
+
+	/* shl/shr across the top bit: a Pauli at qubit
+	 * 0 shifted left by 63 lands at qubit 63 and
+	 * round-trips on shr. */
+	struct paulis ps = paulis_new();
+	paulis_set(&ps, PAULI_Y, 0);
+	paulis_shl(&ps, 63);
+	TEST_EQ(paulis_get(ps, 63), PAULI_Y);
+	TEST_EQ(paulis_get(ps, 0), PAULI_I);
+	paulis_shr(&ps, 63);
+	TEST_EQ(paulis_get(ps, 0), PAULI_Y);
+	TEST_EQ(paulis_get(ps, 63), PAULI_I);
+}
+
+/*
+ * paulis_cmp transitivity: pick three random Pauli
+ * strings, sort them via cmp, verify the implied
+ * order a <= b <= c yields cmp(a, c) <= 0 and
+ * cmp(c, a) >= 0.  Run N iterations.
+ */
+static void t_paulis_cmp_transitive(size_t tag)
+{
+	struct paulis p[3];
+	for (size_t i = 0; i < 3; i++) {
+		p[i] = paulis_new();
+		for (size_t k = 0; k < WIDTH; k++)
+			paulis_set(&p[i],
+				(enum pauli_op)(xoshiro256ss_next(&RNG) % 4),
+				k);
+	}
+
+	/* Tiny three-element sort by cmp. */
+	if (paulis_cmp(p[0], p[1]) > 0) {
+		struct paulis t = p[0];
+		p[0] = p[1];
+		p[1] = t;
+	}
+	if (paulis_cmp(p[1], p[2]) > 0) {
+		struct paulis t = p[1];
+		p[1] = p[2];
+		p[2] = t;
+	}
+	if (paulis_cmp(p[0], p[1]) > 0) {
+		struct paulis t = p[0];
+		p[0] = p[1];
+		p[1] = t;
+	}
+
+	/* Pairwise: with the sort done, cmp(lo, hi) <= 0
+	 * for every (i < j), and antisymmetric reverse. */
+	for (size_t i = 0; i < 3; i++)
+		for (size_t j = i + 1; j < 3; j++) {
+			const int ij = paulis_cmp(p[i], p[j]);
+			const int ji = paulis_cmp(p[j], p[i]);
+			TEST_ASSERT(ij <= 0,
+				"[%zu] cmp(p[%zu], p[%zu]) = %d "
+				"after sort", tag, i, j, ij);
+			TEST_ASSERT(ji >= 0,
+				"[%zu] cmp(p[%zu], p[%zu]) = %d "
+				"after sort", tag, j, i, ji);
+		}
+}
+
 int main(void)
 {
 	world_init(nullptr, nullptr, WD_SEED);
@@ -371,6 +454,10 @@ int main(void)
 		t_paulis_cmp_01(n);
 	for (size_t n = 0; n < 999; n++)
 		t_paulis_cmp_02_eq(n);
+	for (size_t n = 0; n < 999; n++)
+		t_paulis_cmp_transitive(n);
+
+	t_paulis_n63();
 
 	world_free();
 }

--- a/test/t-paulis.c
+++ b/test/t-paulis.c
@@ -26,14 +26,16 @@ static void t_paulis_new(void)
 
 static void t_paulis_getset(size_t tag)
 {
-	int op[WIDTH];
+	enum pauli_op op[WIDTH];
 	struct paulis ps = paulis_new();
 
-	for (size_t k = 0; k < WIDTH; k++)
-		paulis_set(&ps, op[k] = (int)(xoshiro256ss_next(&RNG) % 4), k);
+	for (size_t k = 0; k < WIDTH; k++) {
+		op[k] = (enum pauli_op)(xoshiro256ss_next(&RNG) % 4);
+		paulis_set(&ps, op[k], k);
+	}
 
 	for (size_t k = 0; k < WIDTH; k++) {
-		int p = paulis_get(ps, k);
+		enum pauli_op p = paulis_get(ps, k);
 		TEST_ASSERT(p == op[k], "[%zu] k=%zu, pauli=%d, expected=%d",
 			tag, k, p, op[k]);
 	}
@@ -41,11 +43,11 @@ static void t_paulis_getset(size_t tag)
 
 static void t_paulis_eq(size_t tag)
 {
-	int op;
+	enum pauli_op op = PAULI_I;
 	struct paulis ps1, ps2;
 
 	for (size_t k = 0; k < WIDTH; k++) {
-		op = (int)(xoshiro256ss_next(&RNG) % 4);
+		op = (enum pauli_op)(xoshiro256ss_next(&RNG) % 4);
 		paulis_set(&ps1, op, k);
 		paulis_set(&ps2, op, k);
 	}
@@ -57,12 +59,12 @@ static void t_paulis_eq(size_t tag)
 
 static void t_paulis_shr(size_t n)
 {
-	int op;
+	enum pauli_op op;
 	struct paulis ps1, ps2;
 
 	ps1 = ps2 = paulis_new();
 	for (size_t k = 0; k < WIDTH; k++) {
-		op = (int)(xoshiro256ss_next(&RNG) % 3 + 1); /* no PAULI_I */
+		op = (enum pauli_op)(xoshiro256ss_next(&RNG) % 3 + 1); /* no I */
 		paulis_set(&ps1, op, k);
 		if (k >= n)
 			paulis_set(&ps2, op, k - n);
@@ -183,12 +185,12 @@ static void t_paulis_effect_02(size_t tag)
 {
 	uint64_t x, y, y_exp, kk;
 	_Complex double z, z_exp;
-	int op;
+	enum pauli_op op;
 	struct paulis ps = paulis_new();
 
 	x = xoshiro256ss_next(&RNG);
 	for (size_t k = 0; k < WIDTH; k++)
-		paulis_set(&ps, (int)(xoshiro256ss_next(&RNG) % 4), k);
+		paulis_set(&ps, (enum pauli_op)(xoshiro256ss_next(&RNG) % 4), k);
 
 	y_exp = 0;
 	z_exp = z = 1.0;
@@ -229,14 +231,14 @@ static void t_paulis_split_01(size_t tag)
 {
 	uint32_t lo, hi;
 	struct paulis ps_lo, ps_hi, ps = paulis_new();
-	int op_lo, op_hi, op_ex;
+	enum pauli_op op_lo, op_hi, op_ex;
 
 	lo = xoshiro256ss_next(&RNG) % (WIDTH - 1);
 	hi = xoshiro256ss_next(&RNG) % (WIDTH - lo);
 	TEST_ASSERT(lo + hi <= WIDTH, "wrong test params");
 
 	for (size_t k = 0; k < WIDTH; k++)
-		paulis_set(&ps, (int)(xoshiro256ss_next(&RNG) % 4), k);
+		paulis_set(&ps, (enum pauli_op)(xoshiro256ss_next(&RNG) % 4), k);
 
 	paulis_split(ps, lo, hi, &ps_lo, &ps_hi);
 

--- a/test/t-qreg.c
+++ b/test/t-qreg.c
@@ -23,8 +23,6 @@ static struct world_info WD;
 
 #if PHASE2_BACKEND == 0
 #define MARGIN (1.0e-14)
-#elif PHASE2_BACKEND == 1 /* QuEST */
-#define MARGIN (1.0e-11)
 #elif PHASE2_BACKEND == 2 /* cuQuantum */
 #define MARGIN (1.0e-14)
 #endif /* PHASE2_BACKEND */
@@ -36,9 +34,9 @@ static _Complex double AMPS[NUM_AMPS];
 #define SEED UINT64_C(0x34eaaa33)
 static struct xoshiro256ss RNG;
 
-static int rand_pauli_op(void)
+static enum pauli_op rand_pauli_op(void)
 {
-	return (int)(xoshiro256ss_next(&RNG) % 4);
+	return (enum pauli_op)(xoshiro256ss_next(&RNG) % 4);
 }
 
 static void t_qreg_init(void)
@@ -293,7 +291,7 @@ static void t_qreg_paulirot_02(size_t tag)
 		paulis_set(&ps[1], rand_pauli_op(), k);
 	}
 	for (size_t k = reg.qb_lo; k < reg.qb_lo + reg.qb_hi; k++) {
-		int op = rand_pauli_op();
+		enum pauli_op op = rand_pauli_op();
 		paulis_set(&ps[0], op, k);
 		paulis_set(&ps[1], op, k);
 	}
@@ -364,7 +362,7 @@ static void t_qreg_paulirot_03(size_t tag, size_t n)
 		for (size_t l = 0; l < n; l++)
 			paulis_set(&ps[l], rand_pauli_op(), k);
 	for (size_t k = reg.qb_lo; k < reg.qb_lo + reg.qb_hi; k++) {
-		int op = rand_pauli_op();
+		enum pauli_op op = rand_pauli_op();
 		for (size_t l = 0; l < n; l++)
 			paulis_set(&ps[l], op, k);
 	}


### PR DESCRIPTION
Audit `phase2/paulis.c`.  Five commits.


## enum pauli_op end-to-end; drop QuEST shim

`paulis.h` carried a `#if PHASE2_BACKEND == 1 /
#include "QuEST.h"` conditional that dates from a
QuEST backend the Makefile no longer supports
(current `BACKEND_N` values are 0 for `qreg` and 2
for `cuda`).  The shim that passed `int op` instead
of `enum pauli_op` -- a workaround for QuEST's
clashing `pauliOpType` enum -- is dead.

Drop the conditional; promote the API:

```c
enum pauli_op paulis_get(struct paulis, uint32_t);
void paulis_set(struct paulis *, enum pauli_op,
                uint32_t);
```

Every caller updated to spell out `enum pauli_op`
where it previously used `int`: the tests
(t-paulis, t-circ, t-qreg), the bench helpers
(b-paulis, b-qreg), the ph2run Pauli-string
parser, and `paulis_cmp`'s internal locals.
Three test files (t-circ_trott, t-circ_trott2,
t-qreg) carried dead `#elif PHASE2_BACKEND == 1
/* QuEST */` MARGIN branches; dropped.


## Retire unused paulis_merge; drop redundant const

`paulis_merge` is the inverse of `paulis_split`,
but no caller exists in the tree.  Drop the
prototype and definition.

Drop spurious `const` on by-value parameters in
`paulis.c`.  Same noise pattern cleaned out of
circ in PR #32; the qualifier doesn't reach
callers and isn't conventional in this tree.  The
mask locals in `paulis_split` go the other way --
they earn `const` because they're computed once
and read several times.


## Share paulis_effect between host and device

`phase2/qreg_cuda_lo.cu`'s `__device__
paulisEffect` was a line-for-line reimplementation
of host `paulis_effect`: same two popcounts, same
r4 calculation, same i^r4 phase formula, only the
intrinsic (`__popcll` vs `stdc_count_ones_ul`) and
the complex type (`cuDoubleComplex` vs
`_Complex double`) differed.

Extract the integer-only core to `paulis.h` as a
`__host__ __device__ static inline` helper:

```c
paulis_effect_raw(struct paulis code, uint64_t i,
                  int *r4_out) -> uint64_t
```

Returns the flipped index `j = i ^ pak[0]` and
writes the phase exponent `r4` in `[0, 4)` so the
amplitude on `|j>` picks up a factor of `(i)^r4`.
Uses `__builtin_popcountll`, which compiles to the
native popcount instruction on both gcc (POPCNT)
and nvcc device code (PTX popc.b64).

Two thin wrappers now own only the complex
multiply:

- Host `paulis_effect` (in `paulis.c`) -- 4-element
  `_Complex double` phase table indexed by `r4`.
  Public API unchanged; NULL-z fast path
  preserved.
- Device `kernelPauliRot` (in `qreg_cuda_lo.cu`) --
  `paulisEffect` helper deleted; the kernel calls
  `paulis_effect_raw` directly and reads the
  phase factor from a 4-element `cuDoubleComplex`
  table.

The `PAULIS_HD` macro resolves to
`__host__ __device__` under nvcc (gated by
`__CUDACC__`) and to nothing otherwise, so the
same header serves both compilation paths.


## Reader-guiding documentation pass

The bit-packed encoding and per-function semantics
were inline-commented in `paulis.c`, but the header
was bare.

`include/phase2/paulis.h` gains: a top-of-file
header summarising the symplectic encoding, field
annotation on `struct paulis`, and a one-paragraph
contract on each public function naming the qubit-
index domain, inputs / outputs, aliasing rules,
and the NULL-z fast path in `paulis_effect`.

`phase2/paulis.c` gains short inline notes on
`paulis_split` (mask construction) and
`paulis_cmp` (early `paulis_eq` short-circuit;
MSB-first loop matches lexicographic order on the
bit-string).


## Test coverage: boundary and transitivity

Two scenarios the audit found missing:

- `t_paulis_n63`: set / get at qubit 63 (the top
  bit of the 64-bit word) for each `PAULI_*`.
  Verifies no off-by-one in the bit-shift mask.
  Also exercises `paulis_shl` / `paulis_shr`
  across the boundary.
- `t_paulis_cmp_transitive`: pick three random
  Pauli strings, sort them by `paulis_cmp`,
  verify pairwise relations -- `cmp(lo, hi) <=
  0` and `cmp(hi, lo) >= 0` for every `(i < j)`
  pair in sorted order.  Runs 999 iterations.

The existing test suite covered reflexivity and
antisymmetry of `cmp` plus uniform random sweeps
across qubit indices; transitivity and the top-bit
boundary were assumed but not verified.


## Deferred (explicit non-goals)

- **AVX2 / vectorisation work on the rotation
  inner loop**.  `paulis_effect`'s non-NULL-z
  branch is the hot per-amplitude kernel inside
  `qreg_qreg.c:kernel_rot`, but realistic gains
  need restructuring the (i, j)-pair coupling for
  vectorisation, not just `paulis_effect`.  Plus
  there's no end-to-end benchmark today --
  `bench/b-paulis.c` measures `paulis_effect` in
  isolation, which is the wrong scope.  Belongs
  in a dedicated perf cycle.
- **`make BACKEND=cuda shared` build-system gap**:
  no NVCC rule for the PIC variant of
  `qreg_cuda_lo.o` under `build/shared/`.
  Pre-existing leftover from PR #31's shared-tree
  split; orthogonal to paulis.  Belongs on a
  dedicated `phase2/build-cuda-shared` branch.


## Test plan

Verified both backends compile from a clean tree:

  - **CPU / qreg backend** (default):
    `make clean && make -j$(nproc) all` --
    clean build.
    `make check` -- 31/31 OK.
    `make check-mpi MPIRANKS=2` -- 30/30 OK.
    `make check-paulis` -- 1/1 OK (existing
    scenarios + two new ones).
  - **CUDA backend** (compile-only on the dev host;
    no NVIDIA hardware):
    `make clean && CC=gcc-13 make BACKEND=cuda
    CUDA_PREFIX=/usr -j$(nproc) all` --
    clean build, only nvcc `-arch=native` host-
    discovery warnings (expected without a GPU).

`grep -rn paulis_merge .` -- no hits.
`grep -rn paulisEffect .` -- no hits.
`grep -rn "int op\b" test/ bench/ phase2/ ph2run/`
-- no remaining int op (every Pauli operator is
typed `enum pauli_op`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
