### PR TITLE
state_prep_coeff: scratch hoist + int/out _inner + register-zero invariant

### DIFF
--- a/bench/Makefile
+++ b/bench/Makefile
@@ -1,6 +1,6 @@
 # ========================================================================== #
 # bench -- micro-benchmarks (b-paulis, b-qreg, b-log, b-circ, b-prob,        #
-#                            b-algos)                                        #
+#                            b-algos, b-state-prep-coeff)                    #
 #                                                                            #
 # Each benchmark binary is built from a single b-NAME.c that includes the    #
 # header-only bench.h framework.  No shared bench.o.                         #
@@ -15,7 +15,7 @@ include $(TOPDIR)/build-rules.mk
 
 # Per-benchmark source files; each builds to a binary
 # at $(BUILDDIR)/bench/<name>.
-PROG_NAMES := b-paulis b-qreg b-log b-circ b-prob b-algos
+PROG_NAMES := b-paulis b-qreg b-log b-circ b-prob b-algos b-state-prep-coeff
 PROGS      := $(PROG_NAMES:%=$(BUILDDIR)/bench/%)
 
 # bench's headers live alongside its sources; tell gcc.

--- a/bench/b-state-prep-coeff.c
+++ b/bench/b-state-prep-coeff.c
@@ -1,0 +1,187 @@
+/*
+ * state_prep_coeff: _expand + _inner timing for two
+ * sizes covering N4-class and N8-class fixtures.
+ * Programmatic fixture: random C_alpha / C_beta from
+ * xoshiro256ss; no HDF5 dependency.  Total bench wall
+ * ~1 s on a quiet host.
+ */
+
+#define LOG_SUBSYS "b-state-prep-coeff"
+
+#include "bench.h"
+
+#include <complex.h>
+#include <stdlib.h>
+
+#include "phase2.h"
+#include "phase2/state_prep_coeff.h"
+#include "phase2/world.h"
+#include "xoshiro256ss.h"
+
+#define WD_SEED  UINT64_C(0xb47c0a82d51e9637)
+#define SEED     UINT64_C(0x9e3d5a17c0b46f82)
+
+#define NUM_RUNS 11
+
+static struct xoshiro256ss RNG;
+
+static volatile _Complex double g_sink_z;
+
+
+/* -- table row + JSONL append ----------------------------------------------*/
+
+static void record(FILE *out, const struct bench_prov *prov, int mpi_ranks,
+	const char *name, const char *params_json, const char *display,
+	double *samples, int sub_samples)
+{
+	const struct bench_stats st = bench_compute_stats(samples, NUM_RUNS);
+
+	char path[256];
+	bench_runs_path(prov, path, sizeof path);
+
+	struct bench_baseline bl;
+	const bool has_bl = bench_find_baseline(path, prov->hostname,
+		name, params_json, sub_samples, &bl);
+
+	bench_print_row(display, sub_samples, &st, &bl, has_bl);
+
+	bench_append_jsonl(out, prov, BENCH_BACKEND, mpi_ranks,
+		name, params_json, NUM_RUNS, sub_samples, &st);
+}
+
+
+/* -- scenarios -------------------------------------------------------------*/
+
+/*
+ * For each (n_sites, n_alpha, n_beta) cell: build a
+ * random C_alpha (and reuse it as C_beta), allocate
+ * qreg + scratch, time expand and inner.
+ */
+static void measure_size(FILE *out, const struct bench_prov *prov, int mpi_ranks,
+	uint32_t n_sites, uint32_t n_alpha, uint32_t n_beta,
+	int expand_K, int expand_inner, int inner_K, int inner_inner)
+{
+	const size_t Ca_len = (size_t)n_sites * (n_alpha ? n_alpha : 1);
+	double *Ca = malloc(sizeof *Ca * Ca_len);
+	if (!Ca) {
+		fprintf(stderr, "b-state-prep-coeff: oom Ca\n");
+		return;
+	}
+	for (size_t i = 0; i < Ca_len; i++)
+		Ca[i] = xoshiro256ss_dbl01(&RNG) - 0.5;
+
+	struct qreg reg;
+	if (qreg_init(&reg, 2 * n_sites) < 0) {
+		fprintf(stderr, "b-state-prep-coeff: qreg_init nqb=%u failed\n",
+			2 * n_sites);
+		free(Ca);
+		return;
+	}
+
+	struct state_prep_coeff_scratch sc;
+	if (state_prep_coeff_scratch_init(&sc, n_sites, n_alpha, n_beta) < 0) {
+		fprintf(stderr, "b-state-prep-coeff: scratch_init failed\n");
+		qreg_free(&reg);
+		free(Ca);
+		return;
+	}
+
+	/* Warm-up: prime the qreg pages + cache state. */
+	state_prep_coeff_expand(&reg, &sc, Ca, NULL, 1.0, 0, 0);
+
+	double samples[NUM_RUNS];
+
+	for (int r = 0; r < NUM_RUNS; r++) {
+		BENCH_SAMPLE_MIN(samples[r], expand_K, ({
+			for (int b = 0; b < expand_inner; b++)
+				state_prep_coeff_expand(&reg, &sc,
+					Ca, NULL, 1.0, 0, 0);
+		}));
+		samples[r] /= (double)expand_inner;
+	}
+
+	char params[80];
+	snprintf(params, sizeof params,
+		"{\"n_sites\":%u,\"n_alpha\":%u,\"n_beta\":%u}",
+		n_sites, n_alpha, n_beta);
+	char display[40];
+	snprintf(display, sizeof display, "expand ns=%u na=%u nb=%u",
+		n_sites, n_alpha, n_beta);
+	record(out, prov, mpi_ranks, "expand", params, display,
+		samples, expand_K);
+
+	/* state is already populated by warm-up + measurement
+	 * loop above; ready for inner. */
+	for (int r = 0; r < NUM_RUNS; r++) {
+		BENCH_SAMPLE_MIN(samples[r], inner_K, ({
+			for (int b = 0; b < inner_inner; b++) {
+				_Complex double z = 0.0;
+				state_prep_coeff_inner(&reg, &sc, Ca, NULL,
+					1.0, 0, &z);
+				g_sink_z = z;
+			}
+		}));
+		samples[r] /= (double)inner_inner;
+	}
+
+	snprintf(display, sizeof display, "inner ns=%u na=%u nb=%u",
+		n_sites, n_alpha, n_beta);
+	record(out, prov, mpi_ranks, "inner", params, display,
+		samples, inner_K);
+
+	state_prep_coeff_scratch_free(&sc);
+	qreg_free(&reg);
+	free(Ca);
+}
+
+
+/* -- main ------------------------------------------------------------------*/
+
+int main(void)
+{
+	setenv("PHASE2_LOG", "warn", 0);
+
+	bench_pin_cpu(0);
+
+	world_init(nullptr, nullptr, WD_SEED);
+	struct world_info wd;
+	world_info(&wd);
+	xoshiro256ss_init(&RNG, SEED);
+
+	struct bench_prov prov;
+	bench_prov_init(&prov);
+
+	FILE *out = NULL;
+	if (wd.rank == 0) {
+		char path[256];
+		if (bench_runs_path(&prov, path, sizeof path) < 0) {
+			fprintf(stderr,
+				"b-state-prep-coeff: cannot create bench/runs/\n");
+			world_free();
+			return 1;
+		}
+		out = fopen(path, "a");
+		if (!out) {
+			fprintf(stderr,
+				"b-state-prep-coeff: cannot open %s\n", path);
+			world_free();
+			return 1;
+		}
+		bench_print_banner("b-state-prep-coeff");
+		bench_print_header();
+	}
+
+	/* N4 class (n_sites=4, na=nb=2): 36-term outer
+	 * product, expand ~1 us per call.  K=100 INNER=10.
+	 * N8 class (n_sites=8, na=nb=4): 4900-term outer,
+	 * expand ~hundreds of us per call.  K=10 INNER=1. */
+	measure_size(out, &prov, wd.size, 4, 2, 2,
+		100, 10, 100, 10);
+	measure_size(out, &prov, wd.size, 8, 4, 4,
+		10, 1, 10, 1);
+
+	if (out)
+		fclose(out);
+	world_free();
+	return 0;
+}

--- a/doc/phase2.md
+++ b/doc/phase2.md
@@ -711,6 +711,22 @@ from `/state_prep/coeff_matrix`; no per-determinant
 amplitudes appear in the file (see §3 of
 `doc/simul-h5-specs.md`).
 
+**Scratch lifecycle.**  Slater-Condon expansion needs four
+buffers (alpha / beta k-subset tuples and per-call dets)
+sized by `(n_sites, n_alpha, n_beta)`.  `circ_init`
+allocates a `struct state_prep_coeff_scratch` once when
+`stprep_kind == STPREP_COEFF_MATRIX`, fills the tuples
+(pure combinatorics, no dependence on `C`), and reuses it
+across every `circ_prepst` and `circ_measure` call for the
+lifetime of the `struct circ`.  `circ_free` releases the
+scratch.
+
+**Register-zero invariant.**  `state_prep_coeff_expand_all`
+calls `qreg_zero` internally before writing -- callers do
+not need to zero first.  Pruned slots (coefficient
+magnitude below 1e-12) read as exactly zero after the
+call.
+
 All commands write results back into the respective HDF5
 groups in the simulation file.
 

--- a/include/phase2/circ.h
+++ b/include/phase2/circ.h
@@ -174,6 +174,7 @@ struct circ {
 	struct qreg reg;
 	enum stprep_kind stprep_kind;
 	struct data_coeff_matrix cm;
+	struct state_prep_coeff_scratch sp_scratch;
 };
 
 

--- a/include/phase2/state_prep_coeff.h
+++ b/include/phase2/state_prep_coeff.h
@@ -9,67 +9,66 @@
 struct data_coeff_matrix;
 
 /*
- * state_prep_coeff - Slater-Condon expansion of a coefficient-
- * matrix trial state into a dense MPI-distributed register.
+ * Slater-Condon expansion of a coefficient-matrix trial
+ * state into a dense MPI-distributed register, plus the
+ * matching inner-product readout.
  *
- * Public API:
- *   int state_prep_coeff_expand(struct qreg *reg,
- *           uint32_t n_sites, uint32_t n_alpha, uint32_t n_beta,
- *           const double *C_alpha, const double *C_beta,
- *           double weight, int tapered, int accumulate);
- *   int state_prep_coeff_expand_all(struct qreg *reg,
- *           const struct data_coeff_matrix *cm);
+ * Caller-supplied scratch carries the alpha / beta
+ * k-subset tuples (pure combinatorics; filled once at
+ * init) and the det workspaces (refilled per call from
+ * the current block's C_alpha / C_beta).  One scratch
+ * services any number of _expand / _inner calls sharing
+ * the same (n_sites, n_alpha, n_beta).
  *
- * The trial state is loaded from disk by data_coeff_matrix_load
- * (see ph2run/data.h) and consumed here.
+ * `_expand` writes (accumulate=0) or adds (accumulate=1)
+ * weighted Slater-Condon products
+ *     c = w * det(C_a[occ_a]) * det(C_b[occ_b])
+ * into the owning rank's slice of reg->amp[].  Sparsity
+ * prune: |c| < 1e-12 is skipped.
  *
- * `state_prep_coeff_expand` walks the cartesian product of
- * alpha and beta k-subsets, evaluates the Slater-Condon product
+ * `_expand_all` is the dispatcher used by circ_prepst():
+ * always zeros the register first, then either runs one
+ * single-block expand (accumulate=0) or accumulates over
+ * cm->blocks[].
  *
- *     c(occ_a, occ_b) = w * det(C_a[occ_a, :]) * det(C_b[occ_b, :])
- *
- * and writes (or accumulates) the amplitudes into the slice of
- * `reg->amp[]` owned by this MPI rank.  A single MPI_Barrier
- * is issued at the end.
- *
- * `accumulate == 0` clears each owned slot with the computed
- * coefficient.  `accumulate == 1` adds to the existing slot, as
- * required by the CSF superposition path.  Both modes apply the
- * sparsity prune |c| < 1e-12.
- *
- * `state_prep_coeff_expand_all` is the dispatcher used by
- * `circ_prepst()`: single-block files go through one call with
- * accumulate=0; CSF files zero the register and accumulate.
- *
- * Algorithm reference: phase2/doc/simul-h5-specs.md
- * (`/state_prep/coeff_matrix` section).
+ * `_inner` writes <trial | reg> through `*out`.  The
+ * trial state is real (C is real), so conjugation is
+ * purely on the register amplitudes.  Weight supports
+ * CSF superposition: the full inner product is the
+ * weighted sum over blocks.
  */
 
-int state_prep_coeff_expand(struct qreg *reg, uint32_t n_sites,
-	uint32_t n_alpha, uint32_t n_beta, const double *C_alpha,
-	const double *C_beta, double weight, int tapered, int accumulate);
+struct state_prep_coeff_scratch {
+	uint32_t n_sites, n_alpha, n_beta;
+	uint32_t *tup_a, *tup_b;
+	double   *det_a, *det_b;
+	size_t    Ma, Mb;
+};
 
-int state_prep_coeff_expand_all(
-	struct qreg *reg, const struct data_coeff_matrix *cm);
+/* Allocate scratch buffers and fill the (n_sites,
+ * n_alpha) / (n_sites, n_beta) k-subset tuples.  These
+ * are pure combinatorics and are reused across every
+ * _expand / _inner call against this scratch.  Returns
+ * 0 on success, -1 on size-bound violation or alloc
+ * failure. */
+int state_prep_coeff_scratch_init(struct state_prep_coeff_scratch *sc,
+	uint32_t n_sites, uint32_t n_alpha, uint32_t n_beta);
 
-/*
- * Inner product <trial | reg> over the coefficient-matrix
- * trial state described by (n_sites, n_alpha, n_beta,
- * C_alpha, C_beta, weight, tapered).  Writes the result to
- * `*out` on every rank; returns 0 on success, -1 on error
- * (bad sizes; allocation failure).
- *
- * Walks the same outer product used at expand time, sums
- * weight * conj(C-amplitude(idx)) * reg->amp[idx] over the
- * amplitudes owned by this rank, then MPI_Allreduces the
- * partial sum.  The trial state is taken to be real
- * (C is real), so conjugation is purely on the register
- * amplitudes.  Weight supports the CSF superposition: a
- * CSF inner product is the weighted sum over blocks.
- */
-int state_prep_coeff_inner(struct qreg *reg, uint32_t n_sites,
-	uint32_t n_alpha, uint32_t n_beta, const double *C_alpha,
-	const double *C_beta, double weight, int tapered,
-	_Complex double *out);
+void state_prep_coeff_scratch_free(struct state_prep_coeff_scratch *sc);
+
+/* Returns 0 on success, -1 on error. */
+int state_prep_coeff_expand(struct qreg *reg,
+	struct state_prep_coeff_scratch *sc,
+	const double *C_alpha, const double *C_beta,
+	double weight, int tapered, int accumulate);
+
+int state_prep_coeff_expand_all(struct qreg *reg,
+	struct state_prep_coeff_scratch *sc,
+	const struct data_coeff_matrix *cm);
+
+int state_prep_coeff_inner(struct qreg *reg,
+	struct state_prep_coeff_scratch *sc,
+	const double *C_alpha, const double *C_beta,
+	double weight, int tapered, _Complex double *out);
 
 #endif /* PHASE2_STATE_PREP_COEFF_H */

--- a/include/phase2/state_prep_coeff.h
+++ b/include/phase2/state_prep_coeff.h
@@ -53,22 +53,23 @@ int state_prep_coeff_expand_all(
 	struct qreg *reg, const struct data_coeff_matrix *cm);
 
 /*
- * Inner product <trial | reg> over the coefficient-matrix trial
- * state described by (n_sites, n_alpha, n_beta, C_alpha, C_beta,
- * weight, tapered).
+ * Inner product <trial | reg> over the coefficient-matrix
+ * trial state described by (n_sites, n_alpha, n_beta,
+ * C_alpha, C_beta, weight, tapered).  Writes the result to
+ * `*out` on every rank; returns 0 on success, -1 on error
+ * (bad sizes; allocation failure).
  *
  * Walks the same outer product used at expand time, sums
  * weight * conj(C-amplitude(idx)) * reg->amp[idx] over the
- * amplitudes owned by this rank, and MPI_Allreduces the
- * partial sum.  Returns the inner product on all ranks.
- *
- * The trial state is taken to be real (C is real), so the
- * conjugation is purely on the register amplitudes.  The
- * weight argument supports the CSF superposition: a CSF inner
- * product is the weighted sum over blocks.
+ * amplitudes owned by this rank, then MPI_Allreduces the
+ * partial sum.  The trial state is taken to be real
+ * (C is real), so conjugation is purely on the register
+ * amplitudes.  Weight supports the CSF superposition: a
+ * CSF inner product is the weighted sum over blocks.
  */
-_Complex double state_prep_coeff_inner(struct qreg *reg, uint32_t n_sites,
+int state_prep_coeff_inner(struct qreg *reg, uint32_t n_sites,
 	uint32_t n_alpha, uint32_t n_beta, const double *C_alpha,
-	const double *C_beta, double weight, int tapered);
+	const double *C_beta, double weight, int tapered,
+	_Complex double *out);
 
 #endif /* PHASE2_STATE_PREP_COEFF_H */

--- a/phase2/circ.c
+++ b/phase2/circ.c
@@ -294,8 +294,11 @@ static _Complex double measure_coeff_block(struct qreg *reg,
 	const double *C_alpha, const double *C_beta, double weight,
 	int tapered)
 {
-	return state_prep_coeff_inner(reg, n_sites, n_alpha, n_beta, C_alpha,
-		C_beta, weight, tapered);
+	_Complex double z = 0.0;
+	if (state_prep_coeff_inner(reg, n_sites, n_alpha, n_beta,
+		    C_alpha, C_beta, weight, tapered, &z) < 0)
+		return 0.0;
+	return z;
 }
 
 static _Complex double measure_coeff(struct circ *ct)

--- a/phase2/circ.c
+++ b/phase2/circ.c
@@ -214,16 +214,17 @@ void circ_free(struct circ *ct)
 
 int circ_prepst(struct circ *ct)
 {
-	qreg_zero(&ct->reg);
-
 	switch (ct->stprep_kind) {
 	case STPREP_MULTIDET: {
+		qreg_zero(&ct->reg);
 		const struct circ_muldet *md = &ct->md;
 		for (size_t i = 0; i < md->len; i++)
 			qreg_setamp(&ct->reg, md->dets[i].idx, md->dets[i].cf);
 		return 0;
 	}
 	case STPREP_COEFF_MATRIX:
+		/* state_prep_coeff_expand_all zeros the register
+		 * internally; no separate qreg_zero needed here. */
 		return state_prep_coeff_expand_all(&ct->reg,
 			&ct->sp_scratch, &ct->cm);
 	}

--- a/phase2/circ.c
+++ b/phase2/circ.c
@@ -134,6 +134,7 @@ int circ_init(struct circ *ct, struct circ_hamil hm,
 {
 	memset(&ct->md, 0, sizeof ct->md);
 	memset(&ct->cm, 0, sizeof ct->cm);
+	memset(&ct->sp_scratch, 0, sizeof ct->sp_scratch);
 
 	ct->hm = hm;
 	ct->stprep_kind = sp_kind;
@@ -149,6 +150,12 @@ int circ_init(struct circ *ct, struct circ_hamil hm,
 		ct->cm = *(const struct data_coeff_matrix *)sp_data;
 		log_debug("circ_init: coeff_matrix state (n_components=%zu)",
 			ct->cm.n_components);
+		if (state_prep_coeff_scratch_init(&ct->sp_scratch,
+			    ct->cm.n_sites, ct->cm.n_alpha,
+			    ct->cm.n_beta) < 0) {
+			log_error("circ_init: sp_scratch init failed");
+			goto err_sp_scratch;
+		}
 		break;
 	}
 
@@ -168,12 +175,13 @@ int circ_init(struct circ *ct, struct circ_hamil hm,
 
 	return 0;
 
-	circ_values_free(&ct->vals);
 err_vals_init:
 	circ_cache_free(ct->cache);
 err_cache_init:
 	qreg_free(&ct->reg);
 err_qreg_init:
+	state_prep_coeff_scratch_free(&ct->sp_scratch);
+err_sp_scratch:
 	switch (sp_kind) {
 	case STPREP_MULTIDET:
 		circ_muldet_free(&ct->md);
@@ -196,6 +204,7 @@ void circ_free(struct circ *ct)
 		break;
 	case STPREP_COEFF_MATRIX:
 		data_coeff_matrix_free(&ct->cm);
+		state_prep_coeff_scratch_free(&ct->sp_scratch);
 		break;
 	}
 	circ_cache_free(ct->cache);
@@ -214,16 +223,9 @@ int circ_prepst(struct circ *ct)
 			qreg_setamp(&ct->reg, md->dets[i].idx, md->dets[i].cf);
 		return 0;
 	}
-	case STPREP_COEFF_MATRIX: {
-		struct state_prep_coeff_scratch sc;
-		if (state_prep_coeff_scratch_init(&sc, ct->cm.n_sites,
-			    ct->cm.n_alpha, ct->cm.n_beta) < 0)
-			return -1;
-		const int rc = state_prep_coeff_expand_all(
-			&ct->reg, &sc, &ct->cm);
-		state_prep_coeff_scratch_free(&sc);
-		return rc;
-	}
+	case STPREP_COEFF_MATRIX:
+		return state_prep_coeff_expand_all(&ct->reg,
+			&ct->sp_scratch, &ct->cm);
 	}
 
 	return -1;
@@ -314,25 +316,21 @@ static _Complex double measure_coeff(struct circ *ct)
 	const struct data_coeff_matrix *cm = &ct->cm;
 	_Complex double pr = 0.0;
 
-	struct state_prep_coeff_scratch sc;
-	if (state_prep_coeff_scratch_init(&sc, cm->n_sites,
-		    cm->n_alpha, cm->n_beta) < 0)
-		return 0.0;
-
 	if (cm->n_components == 0) {
-		pr = measure_coeff_block(&ct->reg, &sc, cm->C_alpha,
+		pr = measure_coeff_block(&ct->reg, &ct->sp_scratch,
+			cm->C_alpha,
 			cm->closed_shell ? NULL : cm->C_beta, 1.0,
 			cm->tapered);
 	} else {
 		for (size_t k = 0; k < cm->n_components; k++) {
 			const struct data_coeff_block *b = &cm->blocks[k];
-			pr += measure_coeff_block(&ct->reg, &sc, b->C_alpha,
+			pr += measure_coeff_block(&ct->reg, &ct->sp_scratch,
+				b->C_alpha,
 				cm->closed_shell ? NULL : b->C_beta, b->cf,
 				cm->tapered);
 		}
 	}
 
-	state_prep_coeff_scratch_free(&sc);
 	return pr;
 }
 

--- a/phase2/circ.c
+++ b/phase2/circ.c
@@ -214,8 +214,16 @@ int circ_prepst(struct circ *ct)
 			qreg_setamp(&ct->reg, md->dets[i].idx, md->dets[i].cf);
 		return 0;
 	}
-	case STPREP_COEFF_MATRIX:
-		return state_prep_coeff_expand_all(&ct->reg, &ct->cm);
+	case STPREP_COEFF_MATRIX: {
+		struct state_prep_coeff_scratch sc;
+		if (state_prep_coeff_scratch_init(&sc, ct->cm.n_sites,
+			    ct->cm.n_alpha, ct->cm.n_beta) < 0)
+			return -1;
+		const int rc = state_prep_coeff_expand_all(
+			&ct->reg, &sc, &ct->cm);
+		state_prep_coeff_scratch_free(&sc);
+		return rc;
+	}
 	}
 
 	return -1;
@@ -290,13 +298,13 @@ inline int circ_step_reverse(struct circ *ct, const struct circ_hamil *hm,
  * same order as expansion itself.
  */
 static _Complex double measure_coeff_block(struct qreg *reg,
-	uint32_t n_sites, uint32_t n_alpha, uint32_t n_beta,
+	struct state_prep_coeff_scratch *sc,
 	const double *C_alpha, const double *C_beta, double weight,
 	int tapered)
 {
 	_Complex double z = 0.0;
-	if (state_prep_coeff_inner(reg, n_sites, n_alpha, n_beta,
-		    C_alpha, C_beta, weight, tapered, &z) < 0)
+	if (state_prep_coeff_inner(reg, sc, C_alpha, C_beta,
+		    weight, tapered, &z) < 0)
 		return 0.0;
 	return z;
 }
@@ -306,21 +314,25 @@ static _Complex double measure_coeff(struct circ *ct)
 	const struct data_coeff_matrix *cm = &ct->cm;
 	_Complex double pr = 0.0;
 
+	struct state_prep_coeff_scratch sc;
+	if (state_prep_coeff_scratch_init(&sc, cm->n_sites,
+		    cm->n_alpha, cm->n_beta) < 0)
+		return 0.0;
+
 	if (cm->n_components == 0) {
-		pr = measure_coeff_block(&ct->reg, cm->n_sites, cm->n_alpha,
-			cm->n_beta, cm->C_alpha,
+		pr = measure_coeff_block(&ct->reg, &sc, cm->C_alpha,
 			cm->closed_shell ? NULL : cm->C_beta, 1.0,
 			cm->tapered);
 	} else {
 		for (size_t k = 0; k < cm->n_components; k++) {
 			const struct data_coeff_block *b = &cm->blocks[k];
-			pr += measure_coeff_block(&ct->reg, cm->n_sites,
-				cm->n_alpha, cm->n_beta, b->C_alpha,
+			pr += measure_coeff_block(&ct->reg, &sc, b->C_alpha,
 				cm->closed_shell ? NULL : b->C_beta, b->cf,
 				cm->tapered);
 		}
 	}
 
+	state_prep_coeff_scratch_free(&sc);
 	return pr;
 }
 

--- a/phase2/state_prep_coeff.c
+++ b/phase2/state_prep_coeff.c
@@ -180,17 +180,26 @@ err_tb:
 	return rt;
 }
 
-_Complex double state_prep_coeff_inner(struct qreg *reg,
+int state_prep_coeff_inner(struct qreg *reg,
 	const uint32_t n_sites, const uint32_t n_alpha, const uint32_t n_beta,
 	const double *C_alpha, const double *C_beta, const double weight,
-	const int tapered)
+	const int tapered, _Complex double *out)
 {
-	if (n_alpha > n_sites || n_beta > n_sites)
-		return 0.0;
-	if (n_alpha > DET_SMALL_MAX_N || n_beta > DET_SMALL_MAX_N)
-		return 0.0;
-	if (n_alpha > COMBINATIONS_MAX_K || n_beta > COMBINATIONS_MAX_K)
-		return 0.0;
+	if (n_alpha > n_sites || n_beta > n_sites) {
+		log_error("inner: n_alpha=%u n_beta=%u > n_sites=%u",
+			n_alpha, n_beta, n_sites);
+		return -1;
+	}
+	if (n_alpha > DET_SMALL_MAX_N || n_beta > DET_SMALL_MAX_N) {
+		log_error("inner: n_alpha=%u or n_beta=%u > DET_SMALL_MAX_N=%d",
+			n_alpha, n_beta, DET_SMALL_MAX_N);
+		return -1;
+	}
+	if (n_alpha > COMBINATIONS_MAX_K || n_beta > COMBINATIONS_MAX_K) {
+		log_error("inner: n_alpha=%u or n_beta=%u > COMBINATIONS_MAX_K=%d",
+			n_alpha, n_beta, COMBINATIONS_MAX_K);
+		return -1;
+	}
 
 	const double *Cb = C_beta ? C_beta : C_alpha;
 	const size_t Ma = (size_t)binomial(n_sites, n_alpha);
@@ -198,25 +207,36 @@ _Complex double state_prep_coeff_inner(struct qreg *reg,
 	const uint32_t ka = n_alpha ? n_alpha : 1;
 	const uint32_t kb = n_beta ? n_beta : 1;
 
+	int rt = -1;
+
 	uint32_t *tup_a = malloc(sizeof(uint32_t) * Ma * ka);
-	uint32_t *tup_b = malloc(sizeof(uint32_t) * Mb * kb);
-	double *det_a = malloc(sizeof(double) * Ma);
-	double *det_b = malloc(sizeof(double) * Mb);
-	if (!tup_a || !tup_b || !det_a || !det_b) {
-		free(tup_a);
-		free(tup_b);
-		free(det_a);
-		free(det_b);
-		return 0.0;
+	if (!tup_a) {
+		log_error("inner: alloc tup_a");
+		return -1;
 	}
-	if (precompute_dets(n_sites, n_alpha, C_alpha, tup_a, det_a, Ma) < 0
-		|| precompute_dets(n_sites, n_beta, Cb, tup_b, det_b, Mb)
-			< 0) {
-		free(tup_a);
-		free(tup_b);
-		free(det_a);
-		free(det_b);
-		return 0.0;
+	uint32_t *tup_b = malloc(sizeof(uint32_t) * Mb * kb);
+	if (!tup_b) {
+		log_error("inner: alloc tup_b");
+		goto err_tb;
+	}
+	double *det_a = malloc(sizeof(double) * Ma);
+	if (!det_a) {
+		log_error("inner: alloc det_a");
+		goto err_da;
+	}
+	double *det_b = malloc(sizeof(double) * Mb);
+	if (!det_b) {
+		log_error("inner: alloc det_b");
+		goto err_db;
+	}
+
+	if (precompute_dets(n_sites, n_alpha, C_alpha, tup_a, det_a, Ma) < 0) {
+		log_error("inner: precompute_dets alpha");
+		goto err_pre;
+	}
+	if (precompute_dets(n_sites, n_beta, Cb, tup_b, det_b, Mb) < 0) {
+		log_error("inner: precompute_dets beta");
+		goto err_pre;
 	}
 
 	const int my_rank = reg->wd.rank;
@@ -247,13 +267,17 @@ _Complex double state_prep_coeff_inner(struct qreg *reg,
 	double partial[2] = { acc_r, acc_i };
 	double total[2] = { 0.0, 0.0 };
 	MPI_Allreduce(partial, total, 2, MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
-
-	free(tup_a);
-	free(tup_b);
-	free(det_a);
+	*out = CMPLX(total[0], total[1]);
+	rt = 0;
+err_pre:
 	free(det_b);
-
-	return CMPLX(total[0], total[1]);
+err_db:
+	free(det_a);
+err_da:
+	free(tup_b);
+err_tb:
+	free(tup_a);
+	return rt;
 }
 
 int state_prep_coeff_expand_all(

--- a/phase2/state_prep_coeff.c
+++ b/phase2/state_prep_coeff.c
@@ -267,6 +267,8 @@ int state_prep_coeff_expand_all(struct qreg *reg,
 		cm->n_sites, cm->n_alpha, cm->n_beta, cm->closed_shell,
 		cm->tapered, cm->n_components);
 
+	qreg_zero(reg);
+
 	if (cm->n_components == 0) {
 		if (state_prep_coeff_expand(reg, sc, cm->C_alpha,
 			    cm->closed_shell ? NULL : cm->C_beta, 1.0,
@@ -277,7 +279,6 @@ int state_prep_coeff_expand_all(struct qreg *reg,
 		return 0;
 	}
 
-	qreg_zero(reg);
 	for (size_t k = 0; k < cm->n_components; k++) {
 		const struct data_coeff_block *b = &cm->blocks[k];
 		log_trace("expand_all: block %zu/%zu cf=%.6f", k + 1,

--- a/phase2/state_prep_coeff.c
+++ b/phase2/state_prep_coeff.c
@@ -26,8 +26,12 @@
 
 #include "qreg.h"
 
+/* Coefficient magnitudes below this are skipped at
+ * expand / inner time (sparsity prune). */
 #define SPARSITY_PRUNE (1.0e-12)
 
+/* Pack alpha occupations into the low n_sites bits and
+ * beta occupations into the next n_sites bits. */
 static inline uint64_t occ_pair_to_idx(const uint32_t *occ_a,
 	const uint32_t na, const uint32_t *occ_b, const uint32_t nb,
 	const uint32_t n_sites)
@@ -40,6 +44,9 @@ static inline uint64_t occ_pair_to_idx(const uint32_t *occ_a,
 	return idx;
 }
 
+/* Tapered-state index transform: drop bit 0 (the alpha
+ * symmetry generator) and bit n_sites (the beta one),
+ * compacting the remaining bits into 2*(n_sites-1). */
 static inline uint64_t drop_two_bits(const uint64_t idx, const uint32_t n_sites)
 {
 	const uint64_t lo = (idx >> 1) & ((UINT64_C(1) << (n_sites - 1)) - 1);
@@ -47,6 +54,7 @@ static inline uint64_t drop_two_bits(const uint64_t idx, const uint32_t n_sites)
 	return lo | (hi << (n_sites - 1));
 }
 
+/* C(n, k); 0 when k > n. */
 static uint64_t binomial(const uint32_t n, const uint32_t k)
 {
 	if (k > n)

--- a/phase2/state_prep_coeff.c
+++ b/phase2/state_prep_coeff.c
@@ -1,7 +1,8 @@
 /*
  * Slater-Condon expansion of a coefficient-matrix trial
- * state.  See include/phase2/state_prep_coeff.h for the
- * public API contract; this file holds the implementation.
+ * state, plus the matching inner-product readout.  See
+ * include/phase2/state_prep_coeff.h for the public API
+ * and the scratch contract.
  */
 
 #define LOG_SUBSYS "prep"
@@ -61,100 +62,141 @@ static uint64_t binomial(const uint32_t n, const uint32_t k)
 	return num / den;
 }
 
-/*
- * Enumerate all k-subsets in lex order, fill out[]
- * (size M*k) with the indices, and dets[] (size M) with
- * det(C[occ, :]) for each subset.
- *
- * C is row-major (n_sites, k).  Tuple `occ` selects rows.
- */
-static int precompute_dets(uint32_t n_sites, uint32_t k, const double *C,
-	uint32_t *out_tuples, double *out_dets, size_t M)
+/* Fill out[] (size M*k_eff) with the k-subset tuples of
+ * (n_sites choose k) in lex order.  k_eff is max(k, 1)
+ * so the M=1 / k=0 degenerate case still occupies one
+ * row.  Returns 0 on success, -1 if the iterator yields
+ * the wrong number of tuples. */
+static int precompute_tuples(uint32_t n_sites, uint32_t k,
+	uint32_t *out_tuples, size_t M)
 {
 	struct combo it;
 	combinations_init(&it, n_sites, k);
 
 	uint32_t buf[COMBINATIONS_MAX_K];
-	double sub[DET_SMALL_MAX_N * DET_SMALL_MAX_N];
-
+	const uint32_t k_eff = k ? k : 1;
 	size_t i = 0;
 	while (combinations_next(&it, buf) == 0) {
 		if (i >= M)
 			return -1;
-		if (k == 0) {
-			out_dets[i] = 1.0;
-		} else {
-			for (uint32_t r = 0; r < k; r++) {
-				const uint32_t row = buf[r];
-				for (uint32_t c = 0; c < k; c++)
-					sub[r * k + c] = C[row * k + c];
-			}
-			out_dets[i] = det_small(sub, k);
-		}
 		for (uint32_t r = 0; r < k; r++)
-			out_tuples[i * (k ? k : 1) + r] = buf[r];
+			out_tuples[i * k_eff + r] = buf[r];
 		i++;
 	}
-
-	if (i != M)
-		return -1;
-	return 0;
+	return i == M ? 0 : -1;
 }
 
-int state_prep_coeff_expand(struct qreg *reg, const uint32_t n_sites,
-	const uint32_t n_alpha, const uint32_t n_beta, const double *C_alpha,
-	const double *C_beta, const double weight, const int tapered,
-	const int accumulate)
+/* Walk pre-filled tuples and compute det(C[occ, :]) for
+ * each.  C is row-major (n_sites, k).  k=0 degenerates
+ * to det = 1. */
+static void compute_dets(uint32_t k, const uint32_t *tuples,
+	const double *C, double *out_dets, size_t M)
 {
-	if (n_alpha > n_sites || n_beta > n_sites)
-		return -1;
-	if (n_alpha > DET_SMALL_MAX_N || n_beta > DET_SMALL_MAX_N)
-		return -1;
-	if (n_alpha > COMBINATIONS_MAX_K || n_beta > COMBINATIONS_MAX_K)
-		return -1;
+	if (k == 0) {
+		for (size_t i = 0; i < M; i++)
+			out_dets[i] = 1.0;
+		return;
+	}
+	double sub[DET_SMALL_MAX_N * DET_SMALL_MAX_N];
+	for (size_t i = 0; i < M; i++) {
+		const uint32_t *occ = &tuples[i * k];
+		for (uint32_t r = 0; r < k; r++) {
+			const uint32_t row = occ[r];
+			for (uint32_t c = 0; c < k; c++)
+				sub[r * k + c] = C[row * k + c];
+		}
+		out_dets[i] = det_small(sub, k);
+	}
+}
 
-	const double *Cb = C_beta ? C_beta : C_alpha;
 
-	const size_t Ma = (size_t)binomial(n_sites, n_alpha);
-	const size_t Mb = (size_t)binomial(n_sites, n_beta);
+int state_prep_coeff_scratch_init(struct state_prep_coeff_scratch *sc,
+	uint32_t n_sites, uint32_t n_alpha, uint32_t n_beta)
+{
+	if (n_alpha > n_sites || n_beta > n_sites) {
+		log_error("scratch_init: n_alpha=%u or n_beta=%u > n_sites=%u",
+			n_alpha, n_beta, n_sites);
+		return -1;
+	}
+	if (n_alpha > DET_SMALL_MAX_N || n_beta > DET_SMALL_MAX_N) {
+		log_error("scratch_init: n > DET_SMALL_MAX_N=%d",
+			DET_SMALL_MAX_N);
+		return -1;
+	}
+	if (n_alpha > COMBINATIONS_MAX_K || n_beta > COMBINATIONS_MAX_K) {
+		log_error("scratch_init: n > COMBINATIONS_MAX_K=%d",
+			COMBINATIONS_MAX_K);
+		return -1;
+	}
+
+	memset(sc, 0, sizeof *sc);
+	sc->n_sites = n_sites;
+	sc->n_alpha = n_alpha;
+	sc->n_beta = n_beta;
+	sc->Ma = (size_t)binomial(n_sites, n_alpha);
+	sc->Mb = (size_t)binomial(n_sites, n_beta);
 
 	const uint32_t ka = n_alpha ? n_alpha : 1;
 	const uint32_t kb = n_beta ? n_beta : 1;
 
-	int rt = -1;
+	sc->tup_a = malloc(sizeof *sc->tup_a * sc->Ma * ka);
+	sc->tup_b = malloc(sizeof *sc->tup_b * sc->Mb * kb);
+	sc->det_a = malloc(sizeof *sc->det_a * sc->Ma);
+	sc->det_b = malloc(sizeof *sc->det_b * sc->Mb);
+	if (!sc->tup_a || !sc->tup_b || !sc->det_a || !sc->det_b) {
+		log_error("scratch_init: alloc failed");
+		goto err_alloc;
+	}
 
-	uint32_t *tup_a = malloc(sizeof(uint32_t) * Ma * ka);
-	if (!tup_a)
-		return -1;
-	uint32_t *tup_b = malloc(sizeof(uint32_t) * Mb * kb);
-	if (!tup_b)
-		goto err_tb;
-	double *det_a = malloc(sizeof(double) * Ma);
-	if (!det_a)
-		goto err_da;
-	double *det_b = malloc(sizeof(double) * Mb);
-	if (!det_b)
-		goto err_db;
+	if (precompute_tuples(n_sites, n_alpha, sc->tup_a, sc->Ma) < 0)
+		goto err_alloc;
+	if (precompute_tuples(n_sites, n_beta, sc->tup_b, sc->Mb) < 0)
+		goto err_alloc;
 
-	if (precompute_dets(n_sites, n_alpha, C_alpha, tup_a, det_a, Ma) < 0)
-		goto err_pre;
-	if (precompute_dets(n_sites, n_beta, Cb, tup_b, det_b, Mb) < 0)
-		goto err_pre;
+	return 0;
+
+err_alloc:
+	state_prep_coeff_scratch_free(sc);
+	return -1;
+}
+
+void state_prep_coeff_scratch_free(struct state_prep_coeff_scratch *sc)
+{
+	free(sc->tup_a);
+	free(sc->tup_b);
+	free(sc->det_a);
+	free(sc->det_b);
+	memset(sc, 0, sizeof *sc);
+}
+
+
+int state_prep_coeff_expand(struct qreg *reg,
+	struct state_prep_coeff_scratch *sc,
+	const double *C_alpha, const double *C_beta,
+	const double weight, const int tapered, const int accumulate)
+{
+	const double *Cb = C_beta ? C_beta : C_alpha;
+
+	compute_dets(sc->n_alpha, sc->tup_a, C_alpha, sc->det_a, sc->Ma);
+	compute_dets(sc->n_beta, sc->tup_b, Cb, sc->det_b, sc->Mb);
 
 	const int my_rank = reg->wd.rank;
+	const uint32_t ka = sc->n_alpha ? sc->n_alpha : 1;
+	const uint32_t kb = sc->n_beta ? sc->n_beta : 1;
 
-	for (size_t i = 0; i < Ma; i++) {
-		const double da = det_a[i];
-		const uint32_t *oa = &tup_a[i * ka];
-		for (size_t j = 0; j < Mb; j++) {
-			const double cf = weight * da * det_b[j];
+	for (size_t i = 0; i < sc->Ma; i++) {
+		const double da = sc->det_a[i];
+		const uint32_t *oa = &sc->tup_a[i * ka];
+		for (size_t j = 0; j < sc->Mb; j++) {
+			const double cf = weight * da * sc->det_b[j];
 			if (fabs(cf) < SPARSITY_PRUNE)
 				continue;
-			const uint32_t *ob = &tup_b[j * kb];
+			const uint32_t *ob = &sc->tup_b[j * kb];
 			const uint64_t full = occ_pair_to_idx(
-				oa, n_alpha, ob, n_beta, n_sites);
-			const uint64_t idx =
-				tapered ? drop_two_bits(full, n_sites) : full;
+				oa, sc->n_alpha, ob, sc->n_beta, sc->n_sites);
+			const uint64_t idx = tapered
+				? drop_two_bits(full, sc->n_sites)
+				: full;
 
 			const uint64_t owner = qreg_getihi(reg, idx);
 			if (owner != (uint64_t)my_rank)
@@ -168,92 +210,37 @@ int state_prep_coeff_expand(struct qreg *reg, const uint32_t n_sites,
 	}
 
 	MPI_Barrier(MPI_COMM_WORLD);
-	rt = 0;
-err_pre:
-	free(det_b);
-err_db:
-	free(det_a);
-err_da:
-	free(tup_b);
-err_tb:
-	free(tup_a);
-	return rt;
+	return 0;
 }
 
 int state_prep_coeff_inner(struct qreg *reg,
-	const uint32_t n_sites, const uint32_t n_alpha, const uint32_t n_beta,
-	const double *C_alpha, const double *C_beta, const double weight,
-	const int tapered, _Complex double *out)
+	struct state_prep_coeff_scratch *sc,
+	const double *C_alpha, const double *C_beta,
+	const double weight, const int tapered, _Complex double *out)
 {
-	if (n_alpha > n_sites || n_beta > n_sites) {
-		log_error("inner: n_alpha=%u n_beta=%u > n_sites=%u",
-			n_alpha, n_beta, n_sites);
-		return -1;
-	}
-	if (n_alpha > DET_SMALL_MAX_N || n_beta > DET_SMALL_MAX_N) {
-		log_error("inner: n_alpha=%u or n_beta=%u > DET_SMALL_MAX_N=%d",
-			n_alpha, n_beta, DET_SMALL_MAX_N);
-		return -1;
-	}
-	if (n_alpha > COMBINATIONS_MAX_K || n_beta > COMBINATIONS_MAX_K) {
-		log_error("inner: n_alpha=%u or n_beta=%u > COMBINATIONS_MAX_K=%d",
-			n_alpha, n_beta, COMBINATIONS_MAX_K);
-		return -1;
-	}
-
 	const double *Cb = C_beta ? C_beta : C_alpha;
-	const size_t Ma = (size_t)binomial(n_sites, n_alpha);
-	const size_t Mb = (size_t)binomial(n_sites, n_beta);
-	const uint32_t ka = n_alpha ? n_alpha : 1;
-	const uint32_t kb = n_beta ? n_beta : 1;
 
-	int rt = -1;
-
-	uint32_t *tup_a = malloc(sizeof(uint32_t) * Ma * ka);
-	if (!tup_a) {
-		log_error("inner: alloc tup_a");
-		return -1;
-	}
-	uint32_t *tup_b = malloc(sizeof(uint32_t) * Mb * kb);
-	if (!tup_b) {
-		log_error("inner: alloc tup_b");
-		goto err_tb;
-	}
-	double *det_a = malloc(sizeof(double) * Ma);
-	if (!det_a) {
-		log_error("inner: alloc det_a");
-		goto err_da;
-	}
-	double *det_b = malloc(sizeof(double) * Mb);
-	if (!det_b) {
-		log_error("inner: alloc det_b");
-		goto err_db;
-	}
-
-	if (precompute_dets(n_sites, n_alpha, C_alpha, tup_a, det_a, Ma) < 0) {
-		log_error("inner: precompute_dets alpha");
-		goto err_pre;
-	}
-	if (precompute_dets(n_sites, n_beta, Cb, tup_b, det_b, Mb) < 0) {
-		log_error("inner: precompute_dets beta");
-		goto err_pre;
-	}
+	compute_dets(sc->n_alpha, sc->tup_a, C_alpha, sc->det_a, sc->Ma);
+	compute_dets(sc->n_beta, sc->tup_b, Cb, sc->det_b, sc->Mb);
 
 	const int my_rank = reg->wd.rank;
+	const uint32_t ka = sc->n_alpha ? sc->n_alpha : 1;
+	const uint32_t kb = sc->n_beta ? sc->n_beta : 1;
 
 	double acc_r = 0.0, acc_i = 0.0;
-	for (size_t i = 0; i < Ma; i++) {
-		const double da = det_a[i];
-		const uint32_t *oa = &tup_a[i * ka];
-		for (size_t j = 0; j < Mb; j++) {
-			const double cf = weight * da * det_b[j];
+	for (size_t i = 0; i < sc->Ma; i++) {
+		const double da = sc->det_a[i];
+		const uint32_t *oa = &sc->tup_a[i * ka];
+		for (size_t j = 0; j < sc->Mb; j++) {
+			const double cf = weight * da * sc->det_b[j];
 			if (fabs(cf) < SPARSITY_PRUNE)
 				continue;
-			const uint32_t *ob = &tup_b[j * kb];
+			const uint32_t *ob = &sc->tup_b[j * kb];
 			const uint64_t full = occ_pair_to_idx(
-				oa, n_alpha, ob, n_beta, n_sites);
-			const uint64_t idx =
-				tapered ? drop_two_bits(full, n_sites) : full;
+				oa, sc->n_alpha, ob, sc->n_beta, sc->n_sites);
+			const uint64_t idx = tapered
+				? drop_two_bits(full, sc->n_sites)
+				: full;
 			const uint64_t owner = qreg_getihi(reg, idx);
 			if (owner != (uint64_t)my_rank)
 				continue;
@@ -268,20 +255,12 @@ int state_prep_coeff_inner(struct qreg *reg,
 	double total[2] = { 0.0, 0.0 };
 	MPI_Allreduce(partial, total, 2, MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
 	*out = CMPLX(total[0], total[1]);
-	rt = 0;
-err_pre:
-	free(det_b);
-err_db:
-	free(det_a);
-err_da:
-	free(tup_b);
-err_tb:
-	free(tup_a);
-	return rt;
+	return 0;
 }
 
-int state_prep_coeff_expand_all(
-	struct qreg *reg, const struct data_coeff_matrix *cm)
+int state_prep_coeff_expand_all(struct qreg *reg,
+	struct state_prep_coeff_scratch *sc,
+	const struct data_coeff_matrix *cm)
 {
 	log_debug("expand_all: n_sites=%u n_alpha=%u n_beta=%u"
 		  " closed_shell=%d tapered=%d n_components=%zu",
@@ -289,8 +268,7 @@ int state_prep_coeff_expand_all(
 		cm->tapered, cm->n_components);
 
 	if (cm->n_components == 0) {
-		if (state_prep_coeff_expand(reg, cm->n_sites, cm->n_alpha,
-			    cm->n_beta, cm->C_alpha,
+		if (state_prep_coeff_expand(reg, sc, cm->C_alpha,
 			    cm->closed_shell ? NULL : cm->C_beta, 1.0,
 			    cm->tapered, 0) < 0) {
 			log_error("expand_all: single-block expand failed");
@@ -304,8 +282,7 @@ int state_prep_coeff_expand_all(
 		const struct data_coeff_block *b = &cm->blocks[k];
 		log_trace("expand_all: block %zu/%zu cf=%.6f", k + 1,
 			cm->n_components, b->cf);
-		if (state_prep_coeff_expand(reg, cm->n_sites, cm->n_alpha,
-			    cm->n_beta, b->C_alpha,
+		if (state_prep_coeff_expand(reg, sc, b->C_alpha,
 			    cm->closed_shell ? NULL : b->C_beta, b->cf,
 			    cm->tapered, 1) < 0) {
 			log_error("expand_all: block %zu expand failed", k);

--- a/test/t-circ_prepst_coeff.c
+++ b/test/t-circ_prepst_coeff.c
@@ -5,6 +5,7 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 #include "log.h"
 #include "ph2run/data.h"
@@ -16,7 +17,10 @@
 
 #define WD_SEED UINT64_C(0x7766aa11d8dfbc4c)
 
-static void t_norm_and_structure(void)
+/* Build a fresh circ from the N4_closed fixture.  Caller
+ * owns ct and the open data_id; must call circ_free +
+ * data_close. */
+static data_id open_n4_closed(struct circ *ct)
 {
 	data_id fid = data_open(PH2_TESTDIR "/data/N4_closed.h5");
 	TEST_ASSERT(fid != DATA_INVALID_FID, "open closed");
@@ -29,14 +33,33 @@ static void t_norm_and_structure(void)
 	struct data_coeff_matrix cm;
 	TEST_EQ(data_coeff_matrix_load(fid, &cm), 0);
 
-	struct circ ct = { 0 };
-	TEST_EQ(circ_init(&ct, hm, k, &cm, 1), 0);
+	memset(ct, 0, sizeof *ct);
+	TEST_EQ(circ_init(ct, hm, k, &cm, 1), 0);
+	return fid;
+}
+
+static double sumsq_state(struct qreg *reg, uint32_t nqb)
+{
+	double s = 0.0;
+	const uint64_t namp = UINT64_C(1) << nqb;
+	for (uint64_t i = 0; i < namp; i++) {
+		_Complex double z;
+		qreg_getamp(reg, i, &z);
+		s += creal(z) * creal(z) + cimag(z) * cimag(z);
+	}
+	return s;
+}
+
+static void t_norm_and_structure(void)
+{
+	struct circ ct;
+	data_id fid = open_n4_closed(&ct);
 
 	TEST_EQ(circ_prepst(&ct), 0);
 
+	const uint64_t namp = UINT64_C(1) << ct.cm.nqb;
 	double sumsq = 0.0;
 	int nonzero = 0;
-	const uint64_t namp = UINT64_C(1) << ct.cm.nqb;
 	for (uint64_t i = 0; i < namp; i++) {
 		_Complex double z;
 		qreg_getamp(&ct.reg, i, &z);
@@ -53,9 +76,110 @@ static void t_norm_and_structure(void)
 	data_close(fid);
 }
 
+/*
+ * Two back-to-back circ_prepst calls against the same
+ * cached scratch on struct circ must produce bit-
+ * identical amplitudes.
+ */
+static void t_prepst_idempotent(void)
+{
+	struct circ ct;
+	data_id fid = open_n4_closed(&ct);
+
+	const uint64_t namp = UINT64_C(1) << ct.cm.nqb;
+	_Complex double *snap = malloc(sizeof *snap * namp);
+	TEST_ASSERT(snap != NULL, "alloc snap");
+
+	TEST_EQ(circ_prepst(&ct), 0);
+	for (uint64_t i = 0; i < namp; i++)
+		qreg_getamp(&ct.reg, i, &snap[i]);
+
+	TEST_EQ(circ_prepst(&ct), 0);
+	for (uint64_t i = 0; i < namp; i++) {
+		_Complex double z;
+		qreg_getamp(&ct.reg, i, &z);
+		TEST_ASSERT(z == snap[i],
+			"prepst idempotent: i=%lu first=%g+%gi"
+			" second=%g+%gi", (unsigned long)i,
+			creal(snap[i]), cimag(snap[i]),
+			creal(z), cimag(z));
+	}
+
+	free(snap);
+	circ_free(&ct);
+	data_close(fid);
+}
+
+/*
+ * Evolution between prepst calls must not contaminate
+ * the second prepst.  Gates the expand_all-zeros-itself
+ * contract from commit 4c4be70.
+ */
+static void t_prepst_after_evolution(void)
+{
+	struct circ ct;
+	data_id fid = open_n4_closed(&ct);
+
+	const uint64_t namp = UINT64_C(1) << ct.cm.nqb;
+	_Complex double *snap = malloc(sizeof *snap * namp);
+	TEST_ASSERT(snap != NULL, "alloc snap");
+
+	TEST_EQ(circ_prepst(&ct), 0);
+	for (uint64_t i = 0; i < namp; i++)
+		qreg_getamp(&ct.reg, i, &snap[i]);
+
+	/* Apply one paulirot to dirty the register.  Use the
+	 * first Hamiltonian term, split into hi / lo. */
+	TEST_ASSERT(ct.hm.len > 0, "Hamiltonian has terms");
+	struct paulis lo, hi;
+	paulis_split(ct.hm.terms[0].op, ct.reg.qb_lo, ct.reg.qb_hi,
+		&lo, &hi);
+	const double phi = 0.3;
+	qreg_paulirot(&ct.reg, hi, &lo, &phi, 1);
+
+	TEST_EQ(circ_prepst(&ct), 0);
+	for (uint64_t i = 0; i < namp; i++) {
+		_Complex double z;
+		qreg_getamp(&ct.reg, i, &z);
+		TEST_ASSERT(z == snap[i],
+			"prepst after evolution: i=%lu before=%g+%gi"
+			" after=%g+%gi", (unsigned long)i,
+			creal(snap[i]), cimag(snap[i]),
+			creal(z), cimag(z));
+	}
+
+	free(snap);
+	circ_free(&ct);
+	data_close(fid);
+}
+
+/*
+ * After prepst, the trial-state inner product matches
+ * the squared norm of the register (since the trial
+ * state IS the register at this point).
+ */
+static void t_prepst_then_measure(void)
+{
+	struct circ ct;
+	data_id fid = open_n4_closed(&ct);
+
+	TEST_EQ(circ_prepst(&ct), 0);
+	const double sumsq = sumsq_state(&ct.reg, ct.cm.nqb);
+
+	const _Complex double inner = circ_measure(&ct);
+	TEST_NEAR(creal(inner), sumsq, 1e-12);
+	TEST_NEAR(cimag(inner), 0.0, 1e-12);
+
+	circ_free(&ct);
+	data_close(fid);
+}
+
 int main(void)
 {
 	world_init(nullptr, nullptr, WD_SEED);
 	t_norm_and_structure();
+	t_prepst_idempotent();
+	t_prepst_after_evolution();
+	t_prepst_then_measure();
 	world_free();
 }

--- a/test/t-ref-bendazzoli.c
+++ b/test/t-ref-bendazzoli.c
@@ -112,7 +112,11 @@ static void t_n4_oss_k0_expansion(void)
 	struct qreg reg;
 	TEST_EQ(qreg_init(&reg, cm.nqb), 0);
 	qreg_zero(&reg);
-	TEST_EQ(state_prep_coeff_expand_all(&reg, &cm), 0);
+	struct state_prep_coeff_scratch sc;
+	TEST_EQ(state_prep_coeff_scratch_init(&sc, cm.n_sites,
+		cm.n_alpha, cm.n_beta), 0);
+	TEST_EQ(state_prep_coeff_expand_all(&reg, &sc, &cm), 0);
+	state_prep_coeff_scratch_free(&sc);
 
 	struct ref_amp *ref = malloc(sizeof(*ref) * MAX_EXPECTED);
 	TEST_ASSERT(ref != NULL, "malloc ref");

--- a/test/t-state_prep_coeff_csf.c
+++ b/test/t-state_prep_coeff_csf.c
@@ -30,7 +30,11 @@ static void t_two_component(void)
 	struct qreg reg;
 	TEST_EQ(qreg_init(&reg, cm.nqb), 0);
 	qreg_zero(&reg);
-	TEST_EQ(state_prep_coeff_expand_all(&reg, &cm), 0);
+	struct state_prep_coeff_scratch sc;
+	TEST_EQ(state_prep_coeff_scratch_init(&sc, cm.n_sites,
+		cm.n_alpha, cm.n_beta), 0);
+	TEST_EQ(state_prep_coeff_expand_all(&reg, &sc, &cm), 0);
+	state_prep_coeff_scratch_free(&sc);
 
 	/* Sanity: the superposed state must have at least one
 	 * non-zero amplitude. */
@@ -66,10 +70,13 @@ static void t_single_block_csf_equiv(void)
 	qreg_zero(&r0);
 	qreg_zero(&r1);
 
-	TEST_EQ(state_prep_coeff_expand_all(&r0, &cm), 0);
-	TEST_EQ(state_prep_coeff_expand(&r1, cm.n_sites, cm.n_alpha,
-			cm.n_beta, cm.C_alpha, NULL, 1.0, cm.tapered, 0),
-		0);
+	struct state_prep_coeff_scratch sc;
+	TEST_EQ(state_prep_coeff_scratch_init(&sc, cm.n_sites,
+		cm.n_alpha, cm.n_beta), 0);
+	TEST_EQ(state_prep_coeff_expand_all(&r0, &sc, &cm), 0);
+	TEST_EQ(state_prep_coeff_expand(&r1, &sc, cm.C_alpha, NULL,
+		1.0, cm.tapered, 0), 0);
+	state_prep_coeff_scratch_free(&sc);
 
 	const uint64_t namp = UINT64_C(1) << cm.nqb;
 	for (uint64_t i = 0; i < namp; i++) {

--- a/test/t-state_prep_coeff_expand.c
+++ b/test/t-state_prep_coeff_expand.c
@@ -234,6 +234,50 @@ static void t_boundary_full(void)
 }
 
 /*
+ * One scratch, two expansions with identical inputs must
+ * produce bit-identical amplitudes.  Regression guard for
+ * the scratch lifecycle: tuples filled once at init are
+ * reused; dets recomputed per call from the same C must
+ * land on the same values.
+ */
+static void t_scratch_reuse(void)
+{
+	const uint32_t n_sites = 4, na = 2, nb = 2;
+	double Ca[4 * 2] = {
+		0.6, 0.3,
+		0.2, 0.5,
+		0.1, 0.8,
+		0.4, 0.7,
+	};
+
+	struct qreg r0, r1;
+	TEST_EQ(qreg_init(&r0, 2 * n_sites), 0);
+	TEST_EQ(qreg_init(&r1, 2 * n_sites), 0);
+	qreg_zero(&r0);
+	qreg_zero(&r1);
+
+	struct state_prep_coeff_scratch sc;
+	TEST_EQ(state_prep_coeff_scratch_init(&sc, n_sites, na, nb), 0);
+	TEST_EQ(state_prep_coeff_expand(&r0, &sc, Ca, NULL, 1.0, 0, 0), 0);
+	TEST_EQ(state_prep_coeff_expand(&r1, &sc, Ca, NULL, 1.0, 0, 0), 0);
+	state_prep_coeff_scratch_free(&sc);
+
+	const uint64_t namp = UINT64_C(1) << (2 * n_sites);
+	for (uint64_t i = 0; i < namp; i++) {
+		_Complex double a, b;
+		qreg_getamp(&r0, i, &a);
+		qreg_getamp(&r1, i, &b);
+		TEST_ASSERT(a == b,
+			"scratch reuse: i=%lu a=%g+%gi b=%g+%gi",
+			(unsigned long)i, creal(a), cimag(a),
+			creal(b), cimag(b));
+	}
+
+	qreg_free(&r1);
+	qreg_free(&r0);
+}
+
+/*
  * Dump every non-zero amplitude of the expanded register to
  * `out` as `idx re im` lines, one per line, sorted by idx
  * ascending.  Only rank 0 writes; other ranks remain silent
@@ -345,6 +389,7 @@ int main(int argc, char **argv)
 	t_identity();
 	t_boundary_zero();
 	t_boundary_full();
+	t_scratch_reuse();
 
 	t_fixture(PH2_TESTDIR "/data/N4_closed.h5");
 	t_fixture(PH2_TESTDIR "/data/N4_open.h5");

--- a/test/t-state_prep_coeff_expand.c
+++ b/test/t-state_prep_coeff_expand.c
@@ -122,9 +122,12 @@ static void t_fixture(const char *path)
 	TEST_EQ(qreg_init(&reg, cm.nqb), 0);
 	qreg_zero(&reg);
 
-	TEST_EQ(state_prep_coeff_expand(&reg, cm.n_sites, cm.n_alpha, cm.n_beta,
-			cm.C_alpha, cm.C_beta, 1.0, cm.tapered, 0),
-		0);
+	struct state_prep_coeff_scratch sc;
+	TEST_EQ(state_prep_coeff_scratch_init(&sc, cm.n_sites,
+		cm.n_alpha, cm.n_beta), 0);
+	TEST_EQ(state_prep_coeff_expand(&reg, &sc, cm.C_alpha, cm.C_beta,
+		1.0, cm.tapered, 0), 0);
+	state_prep_coeff_scratch_free(&sc);
 
 	struct ref_amp *refs =
 		malloc(sizeof(struct ref_amp) * (size_t)1 << 18);
@@ -167,9 +170,10 @@ static void t_identity(void)
 	TEST_EQ(qreg_init(&reg, 2 * n_sites), 0);
 	qreg_zero(&reg);
 
-	TEST_EQ(state_prep_coeff_expand(&reg, n_sites, na, nb, Ca, NULL, 1.0,
-			0, 0),
-		0);
+	struct state_prep_coeff_scratch sc;
+	TEST_EQ(state_prep_coeff_scratch_init(&sc, n_sites, na, nb), 0);
+	TEST_EQ(state_prep_coeff_expand(&reg, &sc, Ca, NULL, 1.0, 0, 0), 0);
+	state_prep_coeff_scratch_free(&sc);
 
 	const uint64_t hf = (1u << 0) | (1u << 1) | (1u << (n_sites + 0))
 			    | (1u << (n_sites + 1));
@@ -195,9 +199,10 @@ static void t_boundary_zero(void)
 	struct qreg reg;
 	TEST_EQ(qreg_init(&reg, 2 * n_sites), 0);
 	qreg_zero(&reg);
-	TEST_EQ(state_prep_coeff_expand(
-			&reg, n_sites, 0, 0, NULL, NULL, 1.0, 0, 0),
-		0);
+	struct state_prep_coeff_scratch sc;
+	TEST_EQ(state_prep_coeff_scratch_init(&sc, n_sites, 0, 0), 0);
+	TEST_EQ(state_prep_coeff_expand(&reg, &sc, NULL, NULL, 1.0, 0, 0), 0);
+	state_prep_coeff_scratch_free(&sc);
 	_Complex double z;
 	qreg_getamp(&reg, 0, &z);
 	TEST_NEAR(creal(z), 1.0, 1e-14);
@@ -217,9 +222,10 @@ static void t_boundary_full(void)
 	struct qreg reg;
 	TEST_EQ(qreg_init(&reg, 2 * n_sites), 0);
 	qreg_zero(&reg);
-	TEST_EQ(state_prep_coeff_expand(
-			&reg, n_sites, n_sites, 0, Ca, NULL, 1.0, 0, 0),
-		0);
+	struct state_prep_coeff_scratch sc;
+	TEST_EQ(state_prep_coeff_scratch_init(&sc, n_sites, n_sites, 0), 0);
+	TEST_EQ(state_prep_coeff_expand(&reg, &sc, Ca, NULL, 1.0, 0, 0), 0);
+	state_prep_coeff_scratch_free(&sc);
 	const uint64_t target = 0xfu;
 	_Complex double z;
 	qreg_getamp(&reg, target, &z);
@@ -265,12 +271,22 @@ static int dump_expand(const char *fixture, FILE *out)
 	}
 	qreg_zero(&reg);
 
-	if (state_prep_coeff_expand_all(&reg, &cm) < 0) {
+	struct state_prep_coeff_scratch sc;
+	if (state_prep_coeff_scratch_init(&sc, cm.n_sites,
+		    cm.n_alpha, cm.n_beta) < 0) {
 		qreg_free(&reg);
 		data_coeff_matrix_free(&cm);
 		data_close(fid);
 		return -1;
 	}
+	if (state_prep_coeff_expand_all(&reg, &sc, &cm) < 0) {
+		state_prep_coeff_scratch_free(&sc);
+		qreg_free(&reg);
+		data_coeff_matrix_free(&cm);
+		data_close(fid);
+		return -1;
+	}
+	state_prep_coeff_scratch_free(&sc);
 
 	const uint64_t namp = UINT64_C(1) << cm.nqb;
 	for (uint64_t idx = 0; idx < namp; idx++) {

--- a/test/t-state_prep_coeff_large.c
+++ b/test/t-state_prep_coeff_large.c
@@ -60,11 +60,12 @@ int main(void)
 	TEST_EQ(qreg_init(&reg, 2 * N_SITES), 0);
 	qreg_zero(&reg);
 
+	struct state_prep_coeff_scratch sc;
+	TEST_EQ(state_prep_coeff_scratch_init(&sc, N_SITES, N_OCC, N_OCC), 0);
+
 	struct timespec t1, t2;
 	clock_gettime(CLOCK_MONOTONIC, &t1);
-	TEST_EQ(state_prep_coeff_expand(&reg, N_SITES, N_OCC, N_OCC, Ca, NULL,
-			1.0, 0, 0),
-		0);
+	TEST_EQ(state_prep_coeff_expand(&reg, &sc, Ca, NULL, 1.0, 0, 0), 0);
 	clock_gettime(CLOCK_MONOTONIC, &t2);
 	const double dt =
 		(t2.tv_sec - t1.tv_sec)
@@ -81,8 +82,9 @@ int main(void)
 	 * <psi|psi> directly, which is independent of the
 	 * scatter-and-gather path qreg_getamp would take.
 	 */
-	const _Complex double inner = state_prep_coeff_inner(&reg, N_SITES,
-		N_OCC, N_OCC, Ca, NULL, 1.0, 0);
+	_Complex double inner = 0.0;
+	TEST_EQ(state_prep_coeff_inner(&reg, &sc, Ca, NULL, 1.0, 0, &inner), 0);
+	state_prep_coeff_scratch_free(&sc);
 	const double nsq = creal(inner);
 	fprintf(stderr, "N=14 <psi|psi>: %.6f (imag=%.2e)\n", nsq,
 		cimag(inner));


### PR DESCRIPTION
Audit of `state_prep_coeff` -- the Slater-Condon
expansion of a coefficient-matrix trial state into the
MPI register, plus the matching inner-product readout.

## Economy

- **Scratch buffers hoisted to a `struct
  state_prep_coeff_scratch`** owned by `struct circ`
  for the lifetime of a `STPREP_COEFF_MATRIX` run.
  `circ_init` allocates and fills the alpha / beta
  k-subset tuples (pure combinatorics, fixed for the
  circ's lifetime); `_expand` / `_inner` recompute the
  dets per call from the current block's `C_alpha /
  C_beta` and reuse the cached tuples.

- For CSF runs this collapses 4 mallocs + 4 frees per
  `_expand` (and per `_inner`) into one allocation
  pair per simulation.

## API

- **`state_prep_coeff_inner` returns `int` + output
  param** rather than `_Complex double` with `0+0i` as
  an error sentinel.  Cleanup goes through a
  goto-cleanup ladder matching `_expand`.  Updates
  `measure_coeff_block` in `phase2/circ.c` (the one
  in-tree caller).

- All `state_prep_coeff_*` signatures take a
  `struct state_prep_coeff_scratch *`.  Breaking change
  across `phase2/circ.c` and four test files.

## Correctness

- **`_expand_all` zeros the register itself** on both
  the single-block and CSF paths (previously only the
  CSF path did).  Drops the now-redundant `qreg_zero`
  from `circ_prepst`'s `COEFF_MATRIX` branch.  No net
  cost change; closes the foot-gun where a non-
  `circ_prepst` caller could leave dirty bits in the
  pruned slots.

## Documentation

- Module purpose block + scratch contract in
  `include/phase2/state_prep_coeff.h`.
- One-line docstrings on the file-static helpers in
  `phase2/state_prep_coeff.c` (`occ_pair_to_idx`,
  `drop_two_bits`, `binomial`, `SPARSITY_PRUNE`).
- `doc/phase2.md` §7.5 documents the scratch lifecycle
  and the register-zero invariant.

## Tests

- **`t_scratch_reuse`** (in
  `test/t-state_prep_coeff_expand.c`) -- regression
  guard for the scratch lifecycle: one scratch, two
  `_expand` calls with identical inputs, assert bit-
  identical output.

- **`t-circ_prepst_coeff.c`** extended with three
  integration cases against `N4_closed.h5`:
    - `t_prepst_idempotent`: two back-to-back
      `circ_prepst` calls produce bit-identical state.
    - `t_prepst_after_evolution`: prepst, dirty the
      register via `qreg_paulirot`, prepst again,
      assert second result equals first.  Gates the
      `_expand_all` zero invariant.
    - `t_prepst_then_measure`: after prepst,
      `circ_measure` equals the register's squared
      norm to within 1e-12.  Exercises `_inner` via the
      cached `sp_scratch`.

All 33 C tests pass at single rank and under
`make check-mpi MPIRANKS=4`.

## Benchmarks

- **`bench/b-state-prep-coeff.c`** -- new micro-bench
  covering both operations at two sizes on a
  programmatic random `C` fixture (no HDF5).  N4-class
  (n_sites=4, n_alpha=n_beta=2; 36-term outer
  product) and N8-class (n_sites=8, n_alpha=n_beta=4;
  4900-term outer product).  Locks the scratch-hoist
  economy win as a measurable baseline; future
  regressions in expand / inner show up here.

On a quiet workstation:

  expand ns=4 na=2 nb=2     ~400 ns / call
  inner  ns=4 na=2 nb=2     ~390 ns / call
  expand ns=8 na=4 nb=4     ~30 us / call
  inner  ns=8 na=4 nb=4     ~28 us / call

Adds ~6 s to `make bench`; total wall ~85-90 s on a
quiet host.

## Files

**Modified**:
- `phase2/state_prep_coeff.c`         (commits 1, 2, 4, 5)
- `include/phase2/state_prep_coeff.h` (commits 1, 2)
- `phase2/circ.c`                     (commits 1, 3, 4)
- `include/phase2/circ.h`             (commit 3:
                                       `sp_scratch` field)
- `test/t-state_prep_coeff_csf.c`     (commit 2)
- `test/t-state_prep_coeff_expand.c`  (commits 2, 6)
- `test/t-state_prep_coeff_large.c`   (commit 2)
- `test/t-ref-bendazzoli.c`           (commit 2)
- `test/t-circ_prepst_coeff.c`        (commit 6)
- `doc/phase2.md`                     (commit 7)
- `bench/Makefile`                    (commit 8: bench
                                       added)

**New**:
- `bench/b-state-prep-coeff.c`        (commit 8)

## Test plan

- `make clean && make -j$(nproc) all` -- clean build.
- `make check` -- 33 C tests pass.
- `make check-mpi MPIRANKS=4` -- 33 C tests pass under
  MPI.
- `make check-slow` -- `t-state_prep_coeff_large` runs
  through the new scratch API.
- `make bench` -- bench cells unchanged within noise
  (state_prep_coeff is not on the bench path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
