### PR TITLE
qreg/cuda_lo: include private qreg.h for C linkage

### DIFF
--- a/phase2/qreg_cuda_lo.cu
+++ b/phase2/qreg_cuda_lo.cu
@@ -16,6 +16,7 @@
 
 #include "phase2/paulis.h"
 #include "phase2/qreg.h"
+#include "qreg.h"
 #include "qreg_cuda.h"
 
 constexpr size_t threadPerBlock = 512;


### PR DESCRIPTION
Hotfix: BACKEND=cuda fails to link on a full ph2run build with:

    qreg.c:(.text+0x343): undefined reference to \`qreg_backend_paulirot_lo'

The function's \`extern \"C\"\` declaration lives in
\`phase2/qreg.h\` (the internal header), but
\`qreg_cuda_lo.cu\` wasn't including it, so nvcc emitted
the definition with C++ name mangling.  Add the include.

Symbol now exports as \`T qreg_backend_paulirot_lo\`
(unmangled).  Reported from the Gefion CUDA build.

PR #36 introduced the gap.  My local CUDA test then only
ran the phase2 object build, not the full link.

## Test plan

  - \`make -j\$(nproc) all && make check\` -- CPU
    backend still green.
  - On the CUDA backend, \`make BACKEND=cuda ph2run\`
    links cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)