### PR TITLE
world: drop dead PRNG split + MPI_Finalize safety + docs/tests

### DIFF
--- a/doc/phase2.md
+++ b/doc/phase2.md
@@ -1072,19 +1072,23 @@ struct world_info {
 int world_init(int *argc, char ***argv, uint64_t seed);
 ```
 
-Initialise the global simulation environment.  Must be
-called exactly once at the start of the program.
-Initialises MPI, the logging facility, and the PRNG.
+Initialise the global simulation environment.  Brings up
+MPI (if not already initialised), the logging facility,
+and the backend-specific bits (CUDA device selection on
+the CUDA backend).  Idempotent: a second call with MPI
+already up just refreshes the WORLD snapshot.
 
 **Parameters:**
 - `argc`, `argv`: pointers to command-line argument count
   and vector (forwarded to MPI_Init).  May be NULL.
-- `seed`: seed for the xoshiro256** PRNG.  Must not be
-  zero.  The PRNG state is deterministically split across
-  MPI ranks.
+- `seed`: stored in the world snapshot for downstream
+  consumers (algorithm-level PRNGs seed themselves; the
+  world does not).  Must not be zero.
 
 **Return value:** WORLD_READY on success, WORLD_ERR on
 failure.
+
+The number of MPI ranks must be a power of two.
 
 ---
 
@@ -1093,11 +1097,15 @@ int world_free(void);
 ```
 
 Destroy the global simulation environment.  Finalises MPI
-and the logging facility.  Must be called exactly once at
-the end of the program.
+(if it was initialised, regardless of whether
+`world_init` succeeded later steps) and the
+backend-specific bits.  Safe to call on a
+never-initialised world: returns WORLD_UNDEF in that
+case.
 
-**Return value:** WORLD_DONE on success, WORLD_ERR on
-failure.
+**Return value:** WORLD_DONE on a successful tear-down
+from WORLD_READY; WORLD_UNDEF if no world_init ever ran;
+WORLD_ERR on MPI_Finalize failure.
 
 ---
 

--- a/include/phase2/world.h
+++ b/include/phase2/world.h
@@ -1,6 +1,17 @@
 #ifndef WORLD_H
 #define WORLD_H
 
+/*
+ * Process-lifecycle module.  world_init brings up
+ * MPI, the logging subsystem, and the
+ * backend-specific bits (CUDA device selection on
+ * the CUDA backend); world_free tears them down.
+ * Callers read a snapshot of the lifecycle state
+ * through world_info.
+ *
+ * The number of MPI ranks must be a power of two.
+ */
+
 #include <stdint.h>
 
 enum world_stat {

--- a/phase2/world.c
+++ b/phase2/world.c
@@ -1,3 +1,11 @@
+/*
+ * Process-lifecycle owner: MPI init / finalize, log
+ * init, backend init.  Holds the file-static
+ * WORLD singleton; callers read a snapshot via
+ * world_info.  Per-rank PRNG splitting is not done
+ * here -- algorithms manage their own PRNGs.
+ */
+
 #include "c23_compat.h"
 #include <stdlib.h>
 

--- a/phase2/world.c
+++ b/phase2/world.c
@@ -61,11 +61,15 @@ err:
 
 int world_free(void)
 {
-	if (WORLD.stat == WORLD_READY) {
-		if (MPI_Finalize() == MPI_SUCCESS)
-			WORLD.stat = WORLD_DONE;
-		else
+	int mpi_init = 0;
+	MPI_Initialized(&mpi_init);
+	if (mpi_init) {
+		if (MPI_Finalize() == MPI_SUCCESS) {
+			if (WORLD.stat == WORLD_READY)
+				WORLD.stat = WORLD_DONE;
+		} else {
 			WORLD.stat = WORLD_ERR;
+		}
 	}
 
 	world_backend_destroy(&WORLD);

--- a/phase2/world.c
+++ b/phase2/world.c
@@ -5,7 +5,6 @@
 
 #define LOG_SUBSYS "world"
 #include "log.h"
-#include "xoshiro256ss.h"
 
 #include "phase2/world.h"
 
@@ -15,8 +14,6 @@ static struct world_info WORLD = {
 	.rank = 0,
 	.seed = UINT64_C(0x77dd8e60521fb661),
 };
-
-static struct xoshiro256ss rng;
 
 int world_backend_init(const struct world_info *wd);
 void world_backend_destroy(const struct world_info *wd);
@@ -46,12 +43,7 @@ int world_init(int *argc, char ***argv, uint64_t seed)
 
 	WORLD.size = sz;
 	WORLD.rank = rk;
-
 	WORLD.seed = seed;
-	xoshiro256ss_init(&rng, WORLD.seed);
-	/* Split the state for parrallel distributed computation. */
-	for (int i = 0; i < WORLD.rank; i++)
-		xoshiro256ss_longjump(&rng);
 
 	if (world_backend_init(&WORLD) < 0)
 		goto err;

--- a/phase2/world_cuda.c
+++ b/phase2/world_cuda.c
@@ -1,3 +1,10 @@
+/*
+ * CUDA backend for world.  Picks one GPU per process
+ * via local-rank within an MPI_COMM_TYPE_SHARED
+ * subgroup.  Caller (world_init) wires this in via
+ * world_backend_init.
+ */
+
 #include "c23_compat.h"
 #include <stdlib.h>
 

--- a/test/t-world.c
+++ b/test/t-world.c
@@ -18,6 +18,14 @@ int main(void)
 	world_info(&wd);
 	TEST_ASSERT(wd.stat == WORLD_UNDEF, "wrong status");
 
+	/* world_free on a never-initialised world: should not
+	 * crash, MPI_Finalize is skipped, status stays
+	 * WORLD_UNDEF. */
+	TEST_ASSERT(world_free() == WORLD_UNDEF,
+		"free without init must return WORLD_UNDEF");
+	world_info(&wd);
+	TEST_ASSERT(wd.stat == WORLD_UNDEF, "status drifted on bare free");
+
 	/* Zero seed must be rejected. */
 	TEST_ASSERT(world_init(nullptr, nullptr, 0) == WORLD_ERR,
 		"zero seed should fail");
@@ -31,6 +39,20 @@ int main(void)
 	world_info(&wd);
 	TEST_ASSERT(wd.stat == WORLD_READY, "wrong status");
 	TEST_ASSERT(wd.seed == WD_SEED, "wrong seed");
+
+	const int first_rank = wd.rank;
+	const int first_size = wd.size;
+
+	/* Re-init without an intervening free: MPI is already
+	 * up, so MPI_Init is skipped; world_init repopulates
+	 * the snapshot and the second call also returns
+	 * WORLD_READY with the same rank / size. */
+	TEST_ASSERT(world_init(nullptr, nullptr, WD_SEED) == WORLD_READY,
+		"re-init must succeed");
+	world_info(&wd);
+	TEST_ASSERT(wd.stat == WORLD_READY, "re-init dropped status");
+	TEST_ASSERT(wd.rank == first_rank, "re-init changed rank");
+	TEST_ASSERT(wd.size == first_size, "re-init changed size");
 
 	if (wd.rank == 0)
 		log_info("This is rank no. %d", wd.rank);


### PR DESCRIPTION
Audit of `world` -- the process-lifecycle owner: 212
LOC across `phase2/world.c`, `phase2/world_cuda.c`,
and `include/phase2/world.h`.

## Economy

- **Drop unused per-rank PRNG split.**  `phase2/
  world.c` carried a file-static `xoshiro256ss rng`,
  seeded from `WORLD.seed` and walked through
  `WORLD.rank` longjumps in a loop at `world_init`
  time.  No caller outside `world.c` reads it:
  `qdrift` / `cmpsit` carry their own per-algorithm
  PRNGs seeded from `dt.seed`; everywhere else
  `world_info` is queried only for
  `{stat, size, rank, seed}`.  Drop the static
  rng, the `xoshiro256ss_init`, the O(rank)
  longjump loop, and the `xoshiro256ss.h` include.

## Correctness

- **Finalize MPI from `MPI_Initialized` rather than
  `WORLD.stat`.**  Previously `world_free` skipped
  `MPI_Finalize` when `WORLD.stat == WORLD_ERR`.
  If `world_init` reached `MPI_Init` and then
  failed at a later step (e.g. backend init), MPI
  stayed initialised and the process leaked it.
  Switch to `MPI_Initialized` as the gating
  condition; happy-path `WORLD.stat` transitions
  are unchanged.

## Documentation

- Top-of-file headers on `world.c` and
  `world_cuda.c` (style consistent with the algos
  / qreg / state_prep_coeff audits).
- Module-level purpose paragraph at the top of
  `include/phase2/world.h`.
- `doc/phase2.md` §8.3 refresh: drop the now-
  obsolete PRNG-split language from `world_init`'s
  parameter doc; document `world_free`'s new
  always-finalize behaviour and the WORLD_UNDEF
  return for a never-initialised world.

## Tests

`test/t-world.c` extended with two new assertions:

- **free without init**: `world_free` on a fresh
  world returns `WORLD_UNDEF` and leaves the status
  there.  Exercises the new
  `MPI_Initialized`-driven finalize path on a
  never-initialised MPI.
- **re-init**: `world_init` called twice without an
  intervening `world_free` returns `WORLD_READY`
  both times and leaves rank / size unchanged.
  Documents the idempotence contract.

All 34 C tests pass at single rank and under
`make check-mpi MPIRANKS=4`.

## Decisions deliberately not pursued

- **Constant-time per-rank PRNG split** (the
  original notes flag).  Moot: the split was dead
  code; making dead code faster isn't useful.
- **Global vs threaded `WORLD` refactor**.  `WORLD`
  is opaque to callers (they only read snapshots
  via `world_info`); the current API IS the getter.
  Threading `struct world *` everywhere would
  churn for no clarity win.
- **Folding `world` into qreg**.  Considered.
  Tests that don't use qreg still need MPI;
  `ph2run/data.c` loads data before any qreg
  exists; multi-qreg lifecycle would force
  refcount-based MPI finalize.  World is the right
  scope at the right size (212 LOC).

## Files

**Modified**:
- `phase2/world.c`             (commits 1, 2, 3)
- `phase2/world_cuda.c`        (commit 3)
- `include/phase2/world.h`     (commit 3)
- `test/t-world.c`             (commit 4)
- `doc/phase2.md`              (commit 5)

**No new files.**

## Test plan

  - `make clean && make -j$(nproc) all` -- clean
    build.
  - `make check` -- t-world (with the two new
    cases) green; full suite 34 C tests pass.
  - `make check-mpi MPIRANKS=4` -- world init /
    free exercised under real MPI.
  - `make bench` -- no impact (world is not on
    the bench path); cells stay within noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
