### PR TITLE
state_prep_coeff: cache per-block Slater-Condon minors

### DIFF
--- a/doc/phase2.md
+++ b/doc/phase2.md
@@ -765,15 +765,27 @@ from `/state_prep/coeff_matrix`; no per-determinant
 amplitudes appear in the file (see §3 of
 `doc/simul-h5-specs.md`).
 
-**Scratch lifecycle.**  Slater-Condon expansion needs four
-buffers (alpha / beta k-subset tuples and per-call dets)
-sized by `(n_sites, n_alpha, n_beta)`.  `circ_init`
-allocates a `struct state_prep_coeff_scratch` once when
-`stprep_kind == STPREP_COEFF_MATRIX`, fills the tuples
-(pure combinatorics, no dependence on `C`), and reuses it
-across every `circ_prepst` and `circ_measure` call for the
-lifetime of the `struct circ`.  `circ_free` releases the
-scratch.
+**Scratch lifecycle.**  Slater-Condon expansion needs the
+alpha / beta k-subset tuples (pure combinatorics) sized by
+`(n_sites, n_alpha, n_beta)`, plus the minor determinants
+det(C[occ]) over those tuples.  `circ_init` allocates a
+`struct state_prep_coeff_scratch` once when `stprep_kind ==
+STPREP_COEFF_MATRIX`, fills the tuples (no dependence on
+`C`), and reuses it across every `circ_prepst` and
+`circ_measure` call for the lifetime of the `struct circ`.
+`circ_free` releases the scratch.
+
+The dets are run constants for a fixed `C` — `C` is
+immutable for the scratch's lifetime — so the scratch
+memoises them in a small det cache, one entry per distinct
+`(C_alpha, C_beta)` pair (single-block: one entry; CSF: one
+per block).  The first `_expand` for a pair fills its entry;
+subsequent `_expand` / `_inner` calls with the same pair
+read the cached vectors.  This removes the `O(Ma + Mb)`
+minor walk from the hot measurement path, where `_inner`
+runs once per block per Trotter step.  The result is
+bit-identical to recomputing: `det_small` is a pure
+function of `(tuples, C)`.
 
 **Register-zero invariant.**  `state_prep_coeff_expand_all`
 calls `qreg_zero` internally before writing -- callers do

--- a/include/phase2/state_prep_coeff.h
+++ b/include/phase2/state_prep_coeff.h
@@ -53,11 +53,13 @@ struct data_coeff_matrix;
  */
 
 /*
- * One memoised det vector pair, keyed by the (C_alpha,
- * C_beta) pointers the caller passed.  det_a[Ma] holds
- * det(C_a[occ]) over tup_a; det_b[Mb] holds det(C_b[occ])
- * over tup_b, where C_b is C_beta when non-NULL else
- * C_alpha (the closed-shell fallback the readers apply).
+ * One memoised det vector pair, keyed by the normalised
+ * (C_alpha, C_b) pointers, where C_b is C_beta when
+ * non-NULL else C_alpha (the closed-shell fallback the
+ * readers apply) — so the NULL and C_beta == C_alpha
+ * spellings of a closed-shell block share a slot.
+ * det_a[Ma] holds det(C_a[occ]) over tup_a; det_b[Mb]
+ * holds det(C_b[occ]) over tup_b.
  */
 struct state_prep_coeff_det_slot {
 	const double *key_a, *key_b;

--- a/include/phase2/state_prep_coeff.h
+++ b/include/phase2/state_prep_coeff.h
@@ -15,10 +15,24 @@ struct data_coeff_matrix;
  *
  * Caller-supplied scratch carries the alpha / beta
  * k-subset tuples (pure combinatorics; filled once at
- * init) and the det workspaces (refilled per call from
- * the current block's C_alpha / C_beta).  One scratch
- * services any number of _expand / _inner calls sharing
- * the same (n_sites, n_alpha, n_beta).
+ * init) and a small det cache.  One scratch services any
+ * number of _expand / _inner calls sharing the same
+ * (n_sites, n_alpha, n_beta).
+ *
+ * Det cache: for a fixed coefficient matrix C the products
+ * det(C_a[occ]) / det(C_b[occ]) over the precomputed tuples
+ * are run constants -- C is immutable for the scratch's
+ * lifetime.  The walk over Ma + Mb minors otherwise reruns
+ * on every call, and _inner runs once per CSF block per
+ * Trotter step (the dominant AO measurement cost).  Each
+ * (C_alpha, C_beta) argument pair therefore memoises its
+ * det vectors in a cache slot, keyed by the two pointers and
+ * filled on first use; later calls with the same pair read
+ * the cached vectors instead of recomputing.  The CSF
+ * dispatcher presents at most one pair per block, so the
+ * cache holds one slot per distinct block and grows on
+ * demand.  Bit-identical to recomputing: det_small is a
+ * pure function of (tuples, C).
  *
  * `_expand` writes (accumulate=0) or adds (accumulate=1)
  * weighted Slater-Condon products
@@ -38,11 +52,28 @@ struct data_coeff_matrix;
  * weighted sum over blocks.
  */
 
+/*
+ * One memoised det vector pair, keyed by the (C_alpha,
+ * C_beta) pointers the caller passed.  det_a[Ma] holds
+ * det(C_a[occ]) over tup_a; det_b[Mb] holds det(C_b[occ])
+ * over tup_b, where C_b is C_beta when non-NULL else
+ * C_alpha (the closed-shell fallback the readers apply).
+ */
+struct state_prep_coeff_det_slot {
+	const double *key_a, *key_b;
+	double *det_a, *det_b;
+};
+
 struct state_prep_coeff_scratch {
 	uint32_t n_sites, n_alpha, n_beta;
 	uint32_t *tup_a, *tup_b;
-	double   *det_a, *det_b;
 	size_t    Ma, Mb;
+
+	/* Det cache: see the header comment above.  `slots`
+	 * grows on demand to one entry per distinct
+	 * (C_alpha, C_beta) pair; n_slots <= cap_slots. */
+	struct state_prep_coeff_det_slot *slots;
+	size_t n_slots, cap_slots;
 };
 
 /* Allocate scratch buffers and fill the (n_sites,

--- a/phase2/state_prep_coeff.c
+++ b/phase2/state_prep_coeff.c
@@ -136,7 +136,7 @@ static int dets_for(struct state_prep_coeff_scratch *sc,
 
 	for (size_t s = 0; s < sc->n_slots; s++) {
 		const struct state_prep_coeff_det_slot *sl = &sc->slots[s];
-		if (sl->key_a == C_alpha && sl->key_b == C_beta) {
+		if (sl->key_a == C_alpha && sl->key_b == Cb) {
 			*det_a = sl->det_a;
 			*det_b = sl->det_b;
 			return 0;
@@ -167,7 +167,7 @@ static int dets_for(struct state_prep_coeff_scratch *sc,
 	compute_dets(sc->n_alpha, sc->tup_a, C_alpha, sl->det_a, sc->Ma);
 	compute_dets(sc->n_beta, sc->tup_b, Cb, sl->det_b, sc->Mb);
 	sl->key_a = C_alpha;
-	sl->key_b = C_beta;
+	sl->key_b = Cb;
 	sc->n_slots++;
 
 	*det_a = sl->det_a;

--- a/phase2/state_prep_coeff.c
+++ b/phase2/state_prep_coeff.c
@@ -117,6 +117,64 @@ static void compute_dets(uint32_t k, const uint32_t *tuples,
 	}
 }
 
+/* Resolve the det vectors for the coefficient pair
+ * (C_alpha, C_beta) against the scratch's precomputed
+ * tuples, returning them through *det_a / *det_b.  C_beta
+ * NULL falls back to C_alpha (closed shell), matching the
+ * readers.  Memoised: a slot keyed on the exact (C_alpha,
+ * C_beta) pointers is reused across calls; a miss computes
+ * the vectors once and caches them.  The cache grows on
+ * demand (one slot per distinct pair; CSF presents a
+ * handful).  Keys stay valid because C is immutable for the
+ * scratch's lifetime.  Returns 0 on success, -1 on alloc
+ * failure. */
+static int dets_for(struct state_prep_coeff_scratch *sc,
+	const double *C_alpha, const double *C_beta,
+	const double **det_a, const double **det_b)
+{
+	const double *Cb = C_beta ? C_beta : C_alpha;
+
+	for (size_t s = 0; s < sc->n_slots; s++) {
+		const struct state_prep_coeff_det_slot *sl = &sc->slots[s];
+		if (sl->key_a == C_alpha && sl->key_b == C_beta) {
+			*det_a = sl->det_a;
+			*det_b = sl->det_b;
+			return 0;
+		}
+	}
+
+	if (sc->n_slots == sc->cap_slots) {
+		const size_t cap = sc->cap_slots ? sc->cap_slots * 2 : 4;
+		struct state_prep_coeff_det_slot *grown =
+			realloc(sc->slots, sizeof *grown * cap);
+		if (!grown) {
+			log_error("dets_for: slot array realloc failed");
+			return -1;
+		}
+		sc->slots = grown;
+		sc->cap_slots = cap;
+	}
+
+	struct state_prep_coeff_det_slot *sl = &sc->slots[sc->n_slots];
+	sl->det_a = malloc(sizeof *sl->det_a * sc->Ma);
+	sl->det_b = malloc(sizeof *sl->det_b * sc->Mb);
+	if (!sl->det_a || !sl->det_b) {
+		free(sl->det_a);
+		free(sl->det_b);
+		log_error("dets_for: det vector alloc failed");
+		return -1;
+	}
+	compute_dets(sc->n_alpha, sc->tup_a, C_alpha, sl->det_a, sc->Ma);
+	compute_dets(sc->n_beta, sc->tup_b, Cb, sl->det_b, sc->Mb);
+	sl->key_a = C_alpha;
+	sl->key_b = C_beta;
+	sc->n_slots++;
+
+	*det_a = sl->det_a;
+	*det_b = sl->det_b;
+	return 0;
+}
+
 
 int state_prep_coeff_scratch_init(struct state_prep_coeff_scratch *sc,
 	uint32_t n_sites, uint32_t n_alpha, uint32_t n_beta)
@@ -149,9 +207,7 @@ int state_prep_coeff_scratch_init(struct state_prep_coeff_scratch *sc,
 
 	sc->tup_a = malloc(sizeof *sc->tup_a * sc->Ma * ka);
 	sc->tup_b = malloc(sizeof *sc->tup_b * sc->Mb * kb);
-	sc->det_a = malloc(sizeof *sc->det_a * sc->Ma);
-	sc->det_b = malloc(sizeof *sc->det_b * sc->Mb);
-	if (!sc->tup_a || !sc->tup_b || !sc->det_a || !sc->det_b) {
+	if (!sc->tup_a || !sc->tup_b) {
 		log_error("scratch_init: alloc failed");
 		goto err_alloc;
 	}
@@ -172,8 +228,11 @@ void state_prep_coeff_scratch_free(struct state_prep_coeff_scratch *sc)
 {
 	free(sc->tup_a);
 	free(sc->tup_b);
-	free(sc->det_a);
-	free(sc->det_b);
+	for (size_t s = 0; s < sc->n_slots; s++) {
+		free(sc->slots[s].det_a);
+		free(sc->slots[s].det_b);
+	}
+	free(sc->slots);
 	memset(sc, 0, sizeof *sc);
 }
 
@@ -183,20 +242,19 @@ int state_prep_coeff_expand(struct qreg *reg,
 	const double *C_alpha, const double *C_beta,
 	const double weight, const int tapered, const int accumulate)
 {
-	const double *Cb = C_beta ? C_beta : C_alpha;
-
-	compute_dets(sc->n_alpha, sc->tup_a, C_alpha, sc->det_a, sc->Ma);
-	compute_dets(sc->n_beta, sc->tup_b, Cb, sc->det_b, sc->Mb);
+	const double *det_a, *det_b;
+	if (dets_for(sc, C_alpha, C_beta, &det_a, &det_b) < 0)
+		return -1;
 
 	const int my_rank = reg->wd.rank;
 	const uint32_t ka = sc->n_alpha ? sc->n_alpha : 1;
 	const uint32_t kb = sc->n_beta ? sc->n_beta : 1;
 
 	for (size_t i = 0; i < sc->Ma; i++) {
-		const double da = sc->det_a[i];
+		const double da = det_a[i];
 		const uint32_t *oa = &sc->tup_a[i * ka];
 		for (size_t j = 0; j < sc->Mb; j++) {
-			const double cf = weight * da * sc->det_b[j];
+			const double cf = weight * da * det_b[j];
 			if (fabs(cf) < SPARSITY_PRUNE)
 				continue;
 			const uint32_t *ob = &sc->tup_b[j * kb];
@@ -226,8 +284,6 @@ int state_prep_coeff_inner(struct qreg *reg,
 	const double *C_alpha, const double *C_beta,
 	const double weight, const int tapered, _Complex double *out)
 {
-	const double *Cb = C_beta ? C_beta : C_alpha;
-
 	/* On the CUDA backend the canonical state lives in
 	 * cu->damp; reg->amp may be stale after any kernel
 	 * run (circuit evolution, paulirot, etc.).  Pull the
@@ -235,8 +291,9 @@ int state_prep_coeff_inner(struct qreg *reg,
 	 * backend: no-op + barrier. */
 	qreg_sync_device_to_host(reg);
 
-	compute_dets(sc->n_alpha, sc->tup_a, C_alpha, sc->det_a, sc->Ma);
-	compute_dets(sc->n_beta, sc->tup_b, Cb, sc->det_b, sc->Mb);
+	const double *det_a, *det_b;
+	if (dets_for(sc, C_alpha, C_beta, &det_a, &det_b) < 0)
+		return -1;
 
 	const int my_rank = reg->wd.rank;
 	const uint32_t ka = sc->n_alpha ? sc->n_alpha : 1;
@@ -244,10 +301,10 @@ int state_prep_coeff_inner(struct qreg *reg,
 
 	double acc_r = 0.0, acc_i = 0.0;
 	for (size_t i = 0; i < sc->Ma; i++) {
-		const double da = sc->det_a[i];
+		const double da = det_a[i];
 		const uint32_t *oa = &sc->tup_a[i * ka];
 		for (size_t j = 0; j < sc->Mb; j++) {
-			const double cf = weight * da * sc->det_b[j];
+			const double cf = weight * da * det_b[j];
 			if (fabs(cf) < SPARSITY_PRUNE)
 				continue;
 			const uint32_t *ob = &sc->tup_b[j * kb];


### PR DESCRIPTION
Responds to the det-caching item you flagged as a promptly-reviewable patch in tmm-chomp issue #24.

`compute_dets` ran at the top of both `state_prep_coeff_expand` and `state_prep_coeff_inner` on every call, walking `Ma + Mb` small determinants of the coefficient matrix `C`. `C` is immutable for the scratch's lifetime, so those minors are run constants. The recompute matters most on the readout: `circ_measure -> measure_coeff` drives `_inner` once per CSF block per Trotter step (the dominant AO measurement cost).

This memoises the minors in the scratch — one cache slot per distinct `(C_alpha, C_beta)` pointer pair, filled on first use, grown on demand. In the production flow `circ_prepst -> _expand_all` runs `_expand` for every block before any measurement, so each block's slot is primed by the first prepst and every subsequent `_inner` reads cached vectors. The old per-call `det_a/det_b` workspaces are removed; the slots own that storage.

**Behaviour-identical:** `det_small` is a pure function of `(tuples, C)`, and the cache returns the same values in the same order — bit-for-bit. Public signatures are unchanged, so the existing regression net carries over directly: `t-state_prep_coeff_expand::t_scratch_reuse`, `t-circ_prepst_coeff::t_prepst_{idempotent,then_measure,after_evolution}`, the CSF multi-block path in `t-state_prep_coeff_csf`, and the trott/trott2 coeff tests.

**CI caveat:** I could not run `make check` locally (developed on macOS arm64, where `-march=native -mavx2` and the hard-coded Linux MPI/HDF5 paths block the build). I verified the changed translation units compile clean under `clang -fsyntax-only -std=c11 -Wall -Wextra` with the repo include paths. The Ubuntu CI `make && make check` is the gate.

🤖 Generated with Claude Code
