### PR TITLE
state_prep_coeff: OpenMP-parallelise the inner-product walk

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,10 +36,13 @@ EXTRA_LDFLAGS   ?=
 # flags are split so both the ph2run/test link (LDFLAGS) and
 # the shared-library link (SHARED_LDFLAGS) pick up the runtime.
 # GCC spells both -fopenmp; override on a toolchain that
-# differs (e.g. a non-GNU clang: OPENMP_CFLAGS='-Xpreprocessor
-# -fopenmp', OPENMP_LDFLAGS='-lomp').  Set both empty to build
-# without OpenMP -- the pragma is then ignored and the walk
-# runs serially.
+# differs.  A non-GNU clang with libomp typically needs the
+# include and library paths as well, e.g.
+#   OPENMP_CFLAGS='-Xpreprocessor -fopenmp -I<libomp>/include'
+#   OPENMP_LDFLAGS='-L<libomp>/lib -lomp'
+# Set both empty to build without OpenMP -- the pragma is
+# compiled out (it is guarded on _OPENMP) and the walk runs
+# serially.
 OPENMP_CFLAGS   ?= -fopenmp
 OPENMP_LDFLAGS  ?= -fopenmp
 

--- a/Makefile
+++ b/Makefile
@@ -24,11 +24,24 @@
 
 # --- Toolchain ------------------------------------------------------------- #
 CC              ?= gcc
-CFLAGS          += -std=c11 -Wall -Wextra -O3 -march=native -mavx2 -MMD -MP
+CFLAGS          += -std=c11 -Wall -Wextra -O3 -march=native -mavx2 -MMD -MP \
+                   $(OPENMP_CFLAGS)
 # EXTRA_CFLAGS / EXTRA_LDFLAGS allow command-line overrides (e.g. sanitiser
 # builds) without clobbering the rest of the flag pipeline.
 EXTRA_CFLAGS    ?=
 EXTRA_LDFLAGS   ?=
+
+# OpenMP: shared-memory threading for the coeff-matrix inner-
+# product walk (state_prep_coeff_inner).  Compile and link
+# flags are split so both the ph2run/test link (LDFLAGS) and
+# the shared-library link (SHARED_LDFLAGS) pick up the runtime.
+# GCC spells both -fopenmp; override on a toolchain that
+# differs (e.g. a non-GNU clang: OPENMP_CFLAGS='-Xpreprocessor
+# -fopenmp', OPENMP_LDFLAGS='-lomp').  Set both empty to build
+# without OpenMP -- the pragma is then ignored and the walk
+# runs serially.
+OPENMP_CFLAGS   ?= -fopenmp
+OPENMP_LDFLAGS  ?= -fopenmp
 
 # --- System library root --------------------------------------------------- #
 # Most Debian/Ubuntu installs put MPI and HDF5 dynamic libs under
@@ -146,7 +159,8 @@ CFLAGS          += -I$(INCLUDE) $(MPI_CFLAGS) $(HDF5_CFLAGS)	\
                    -DPHASE2_VERSION=\"$(VERSION)\"		\
                    $(EXTRA_CFLAGS)
 LDFLAGS         += $(MPI_LDFLAGS) $(HDF5_LDFLAGS)		\
-                   $(BACKEND_LDFLAGS) $(EXTRA_LDFLAGS)
+                   $(BACKEND_LDFLAGS) $(OPENMP_LDFLAGS)		\
+                   $(EXTRA_LDFLAGS)
 LDLIBS          += -lm $(MPI_LDLIBS) $(HDF5_LDLIBS) $(BACKEND_LDLIBS)
 
 # --- Helpers --------------------------------------------------------------- #
@@ -226,7 +240,10 @@ build-test-slow: phase2 circ lib ph2run-data
 # objects build under $(BUILDDIR)/shared/<srcdir>/ on a disjoint path
 # from the regular tree, so `make build` and `make shared` cannot mix
 # PIC and non-PIC objects.
-SHARED_LDFLAGS := $(MPI_LDFLAGS) $(BACKEND_LDFLAGS)
+# OPENMP_LDFLAGS is required here too: state_prep_coeff.o is
+# compiled with OPENMP_CFLAGS and pulls in the OpenMP runtime,
+# which libphase2.so must resolve at link.
+SHARED_LDFLAGS := $(MPI_LDFLAGS) $(BACKEND_LDFLAGS) $(OPENMP_LDFLAGS)
 SHARED_LDLIBS  := $(MPI_LDLIBS) $(BACKEND_LDLIBS)
 SHARED_OBJS    := $(BUILDDIR)/shared/phase2/phase2_run.o		\
                   $(patsubst $(BUILDDIR)/%,$(BUILDDIR)/shared/%,	\

--- a/phase2/state_prep_coeff.c
+++ b/phase2/state_prep_coeff.c
@@ -15,6 +15,10 @@
 #include <stdlib.h>
 #include <string.h>
 
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
 #include "mpi.h"
 
 #include "combinations.h"
@@ -242,7 +246,23 @@ int state_prep_coeff_inner(struct qreg *reg,
 	const uint32_t ka = sc->n_alpha ? sc->n_alpha : 1;
 	const uint32_t kb = sc->n_beta ? sc->n_beta : 1;
 
+	/* The outer walk is a pure map-reduce: every body
+	 * local is declared in-loop (hence thread-private),
+	 * the reads (det_a / det_b, tup_a / tup_b, reg->amp)
+	 * are const for the duration, and the only carried
+	 * state is the acc_r / acc_i sum -> an OpenMP
+	 * reduction.  Builds without -fopenmp ignore the
+	 * pragma and run the serial loop unchanged.  The
+	 * reduction reorders the cross-thread partial sums,
+	 * so the result can differ from the serial order in
+	 * the last ULPs; this is an O(Ma * Mb) measurement
+	 * accumulator whose terms are already summed in an
+	 * MPI_Allreduce below (itself order-unspecified
+	 * across ranks), so floating-point associativity is
+	 * not relied upon here.  At OMP_NUM_THREADS=1 the
+	 * order is identical to the serial loop. */
 	double acc_r = 0.0, acc_i = 0.0;
+#pragma omp parallel for reduction(+ : acc_r, acc_i)
 	for (size_t i = 0; i < sc->Ma; i++) {
 		const double da = sc->det_a[i];
 		const uint32_t *oa = &sc->tup_a[i * ka];

--- a/phase2/state_prep_coeff.c
+++ b/phase2/state_prep_coeff.c
@@ -262,7 +262,9 @@ int state_prep_coeff_inner(struct qreg *reg,
 	 * not relied upon here.  At OMP_NUM_THREADS=1 the
 	 * order is identical to the serial loop. */
 	double acc_r = 0.0, acc_i = 0.0;
+#ifdef _OPENMP
 #pragma omp parallel for reduction(+ : acc_r, acc_i)
+#endif
 	for (size_t i = 0; i < sc->Ma; i++) {
 		const double da = sc->det_a[i];
 		const uint32_t *oa = &sc->tup_a[i * ka];


### PR DESCRIPTION
Responds to the OpenMP `_inner` reduction item you flagged as a promptly-reviewable patch in tmm-chomp issue #24.

`state_prep_coeff_inner` is the coeff-matrix measurement kernel — `circ_measure -> measure_coeff` calls it once per CSF block per Trotter step, and its `O(Ma * Mb)` walk over the Slater-Condon outer product dominates the AO measurement cost. The outer loop is a textbook map-reduce: every body local is declared in-loop (thread-private), the inputs (`det_a/det_b`, `tup_a/tup_b`, `reg->amp`) are read-only, and the only loop-carried state is the `acc_r/acc_i` accumulation. This annotates it with `#pragma omp parallel for reduction(+:acc_r,acc_i)`.

No MPI call occurs inside the region — the two body helpers (`qreg_getihi/getilo`) are pure bit masks, and the `MPI_Allreduce` runs after the loop on the master thread only. So plain `MPI_Init` / `MPI_THREAD_SINGLE` (as `world_init` uses) stays correct; no thread-level upgrade needed.

**Behaviour-identical at `OMP_NUM_THREADS=1`** (loop runs in the original order). With more threads the reduction reorders the cross-thread partial sums, so the result can differ in the last ULPs. That is acceptable here: the per-rank sum already feeds an `MPI_Allreduce` whose cross-rank summation order is unspecified, so the measurement does not rely on a fixed floating-point association. `state_prep_coeff_expand` is left serial on purpose — its `reg->amp[i_lo] +=` scatter can collide on post-taper indices.

Build: `-fopenmp` is added via new `OPENMP_CFLAGS`/`OPENMP_LDFLAGS` knobs in Section 1, split so the shared-library link (which doesn't inherit `LDFLAGS`) also resolves the runtime; clearing them yields a correct serial build. `#include <omp.h>` is guarded by `#ifdef _OPENMP`.

**CI caveat:** developed on macOS arm64, where the repo's `gcc` is Apple clang (rejects bare `-fopenmp`) and `-mavx2` plus the Linux MPI/HDF5 paths block `make` — so I could not run `make check` locally. I verified the kernel compiles clean under `clang -fsyntax-only` both with and without OpenMP, and that the object emits the expected `__kmpc_*` reduction calls and links against the OpenMP runtime. The Ubuntu CI `make && make check` (which runs multi-threaded, as it sets no `OMP_NUM_THREADS`) is the gate.

Note: trivial textual overlap with #42 in `_inner`'s det setup (this pragma sits on the `for` loop both patches keep) — one-line resolution for whichever merges second.

🤖 Generated with Claude Code
