### PR TITLE
release: phase2 1.2.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ BUILDDIR        := $(CURDIR)/build
 
 # --- Version --------------------------------------------------------------- #
 VERSION_MAJOR   := 1
-VERSION_MINOR   := 1
+VERSION_MINOR   := 2
 VERSION_PATCH   := 0
 VERSION         := $(VERSION_MAJOR).$(VERSION_MINOR).$(VERSION_PATCH)
 

--- a/doc/phase2.md
+++ b/doc/phase2.md
@@ -3,7 +3,7 @@
 Full-state vector quantum Hamiltonian simulation library for
 quantum phase estimation.
 
-Version 1.1.0
+Version 1.2.0
 
 Copyright (c) 2025, Marek Miller.  BSD 3-Clause License.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "phase2"
-version = "1.1.0"
+version = "1.2.0"
 description = "Python interface to the phase2 MPI Hamiltonian simulator"
 license = "BSD-3-Clause"
 requires-python = ">=3.10"

--- a/util/_ph2/__init__.py
+++ b/util/_ph2/__init__.py
@@ -6,7 +6,7 @@ that `ph2.py --help` works in a bare interpreter; submodules import
 the heavy dependencies at their own top level instead.
 """
 
-__version__ = "1.1.0"
+__version__ = "1.2.0"
 
 # Result groups a worksheet may carry, with the attributes each one
 # is required to have (doc/simul-h5-specs.md; /circ_qdrift "seed" is


### PR DESCRIPTION
## Changes since v1.1

### Toolkit
- Add `util/ph2.py`, a CLI over `simul.h5`: subcommands `show`,
  `validate`, `hamil` (FCIDUMP and Pauli-text), `stprep` (multidet and
  coeff_matrix), `energy` (fft, mc, ref, rpe, rpe-qdrift), `strip`,
  `diff`, `attr`. Manual: `doc/ph2.md`. (#44)

### Examples
- Merge `simul/` and `scripts/` into `examples/`; pipelines and fixture
  regeneration run through `ph2`. (#41, #44)
- Energy extraction: FFT for `trott`/`trott2`, averaged-overlap phase
  for `qdrift`/`cmpsit`; output `E,E_ref,dE`. (#41)
- Add `examples/TUTORIAL.md`. (#41)

### Core
- qreg: paulirot dispatch behind backend hooks; CUDA host/device sync;
  `struct qreg::data` renamed `backend`. (#36, #38, #39)
- state_prep_coeff: per-`circ` scratch reuse; `_inner` int + output
  param. (#37, #39)
- world: `world_free` finalises MPI from `MPI_Initialized`. (#40)
- circ algorithms: `prob` moved to `lib/`; qdrift/cmpsit
  `--step-size`/`--angle-det` long-only flags. (#35)

### Build / tests / bench
- Build artefacts under `build/`; per-subsystem recursive makefiles. (#31)
- Parallel test runner with per-test capture and filtering. (#30)
- Benchmark framework: JSONL records, per-host baselines, four binaries. (#34)

### Docs
- Add `doc/ph2.md`; record `/circ_qdrift@seed` in
  `doc/simul-h5-specs.md`; README worksheet-toolkit section. (#44)
