### PR TITLE
lib/xoshiro256ss: drop the GPLv3 header

### DIFF
--- a/include/xoshiro256ss.h
+++ b/include/xoshiro256ss.h
@@ -1,21 +1,4 @@
-/* -------------------------------------------------------------------------- *
- * xoshiro256ss.h: A thread-safe implementation of xoshiro256starstar PRNG.   *
- *                                                                            *
- * Copyright 2024 ⧉⧉⧉                                                         *
- *                                                                            *
- * This program is free software: you can redistribute it and/or modify it    *
- * under the terms of the GNU General Public License as published by the      *
- * Free Software Foundation, either version 3 of the License, or (at your     *
- * option) any later version.                                                 *
- *                                                                            *
- * This program is distributed in the hope that it will be useful, but        *
- * WITHOUT ANY WARRANTY* without even the implied warranty of MERCHANTABILITY *
- * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License   *
- * for more details.                                                          *
- *                                                                            *
- * You should have received a copy of the GNU General Public License along    *
- * with this program.  If not, see <https://www.gnu.org/licenses/>.           *
- * -------------------------------------------------------------------------- */
+/* xoshiro256ss.h: A thread-safe implementation of xoshiro256starstar PRNG. */
 #ifndef XOSHIRO256SS_H
 #define XOSHIRO256SS_H
 
@@ -30,8 +13,8 @@
  *   https://doi.org/10.1145/3460772                                          *
  *                                                                            *
  * The original implementation uses a static internal state for the PRNG.     *
- * To make the functions thread-safe, we modify them to accept a local state. *
- * implementation is thread-safe.                                             *
+ * The functions here take a caller-owned state instead, which makes them     *
+ * thread-safe.                                                               *
  *                                                                            *
  * The implementation by Blackman and Vigna is part of Public Domain.         *
  * See <http://creativecommons.org/publicdomain/zero/1.0/>.                   *

--- a/lib/xoshiro256ss.c
+++ b/lib/xoshiro256ss.c
@@ -1,24 +1,6 @@
-/* -------------------------------------------------------------------------- *
- * xoshiro256ss.c: A thread-safe implementation of xoshiro256starstar PRNG.   *
- *                                                                            *
- * Copyright 2018 David Blackman and Sebastiano Vigna                         *
- * Copyright 2024 ⧉⧉⧉                                                         *
- *                                                                            *
- * This program is free software: you can redistribute it and/or modify it    *
- * under the terms of the GNU General Public License as published by the      *
- * Free Software Foundation, either version 3 of the License, or (at your     *
- * option) any later version.                                                 *
- *                                                                            *
- * This program is distributed in the hope that it will be useful, but        *
- * WITHOUT ANY WARRANTY* without even the implied warranty of MERCHANTABILITY *
- * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License   *
- * for more details.                                                          *
- *                                                                            *
- * You should have received a copy of the GNU General Public License along    *
- * with this program.  If not, see <https://www.gnu.org/licenses/>.           *
- * -------------------------------------------------------------------------- */
+/* xoshiro256ss.c: A thread-safe implementation of xoshiro256starstar PRNG. */
 
-/*  Written in 2018 by David Blackman and Sebarngiano Vigna (vigna@acm.org)
+/*  Written in 2018 by David Blackman and Sebastiano Vigna (vigna@acm.org)
 
 To the extent possible under law, the author has dedicated all copyright
 and related and neighboring rights to this software to the public domain


### PR DESCRIPTION
The GPL blocks in `lib/xoshiro256ss.c` and `include/xoshiro256ss.h` contradicted the repo-wide BSD-3-Clause LICENSE. The base code is Blackman and Vigna's CC0 reference implementation (the dedication stays in the `.c`); the thread-safety modifications and the GPL notice itself are the repo author's own, so no third-party GPL rights are involved. Per-file license blocks are reserved for vendored third-party code (`jsmn.h`); everything else is governed by LICENSE.

Also fixes a name typo in the CC0 dedication and a garbled sentence in the header's provenance comment. Comment-only diff; full suite green serially and under `mpirun -n 4`.

🤖 Generated with Claude Code