### PR TITLE
world: drop the stale PRNG-split claim from world_init doc

### DIFF
--- a/include/phase2/world.h
+++ b/include/phase2/world.h
@@ -40,12 +40,12 @@ struct world_info {
 
 /* Initialize the world with command line parameters and a seed for PRNG.
  *
- * This should be called exactly once at the begging of the program.  The MPI
+ * This should be called exactly once at the beginning of the program.  The MPI
  * world communicator is initialized here as well as the logging facility.
  *
- * The PRNG is initialized with the seed.  The seed must not be zero.  The state
- * of the PRNG is deterministically split among MPI processes, so that each
- * process has it own state.
+ * The seed must not be zero.  It is stored in the world snapshot (readable
+ * via world_info); the world owns no PRNG state.  Algorithms seed their own
+ * PRNGs from it, identically on every rank.
  *
  * Returns:
  * 	WORLD_READY	- in case of success


### PR DESCRIPTION
Per-rank PRNG splitting was removed in the world audit (#40), but the `world_init` doc comment in `include/phase2/world.h` still claimed the PRNG state is "deterministically split among MPI processes". Rewritten to match reality: the seed is validated and stored in the world snapshot (readable via `world_info`); algorithms own their PRNGs and seed every rank identically by design — all ranks must draw the same Hamiltonian terms. Also fixes a typo.

Comment-only diff; suite green serially and under `mpirun -n 4`.

🤖 Generated with Claude Code