### PR TITLE
circ: use the PRNG seed literally, drop the SEED globals

### DIFF
--- a/circ/cmpsit.c
+++ b/circ/cmpsit.c
@@ -26,8 +26,6 @@
 
 #include "internal.h"
 
-static uint64_t SEED = UINT64_C(0xafb424901446f21f);
-
 #ifndef FRAC_PI_2
 #define FRAC_PI_2 1.57079632679489661923132169163975144
 #endif
@@ -127,10 +125,6 @@ int cmpsit_init(struct cmpsit *cp, const struct cmpsit_data *dt,
 	if (ranct_init(&cp->ranct, &cp->ct.hm, dt) < 0)
 		goto err_ranct_init;
 
-	if (cp->dt.seed != 0)
-		SEED = cp->dt.seed;
-	else
-		cp->dt.seed = SEED;
 	xoshiro256ss_init(&cp->rng, cp->dt.seed);
 
 	return 0;

--- a/circ/qdrift.c
+++ b/circ/qdrift.c
@@ -26,8 +26,6 @@
 
 #include "internal.h"
 
-static uint64_t SEED = UINT64_C(0xeccd9dcc749fcdca);
-
 static int ranct_init(struct qdrift_ranct *rct, const uint32_t qb,
 	const size_t depth, const size_t cdf_len)
 {
@@ -68,10 +66,6 @@ int qdrift_init(struct qdrift *qd, const struct qdrift_data *dt,
 		goto err_rct_init;
 	ranct_calc_cdf(&qd->ranct, qd->ct.hm.terms);
 
-	if (qd->dt.seed != 0)
-		SEED = qd->dt.seed;
-	else
-		qd->dt.seed = SEED;
 	xoshiro256ss_init(&qd->rng, qd->dt.seed);
 
 	return 0;

--- a/include/circ/cmpsit.h
+++ b/include/circ/cmpsit.h
@@ -22,8 +22,9 @@
  * sample at omega = 0.5, then a reverse half-sweep of an
  * independent sample — yielding the symmetric S_2 integrator.
  *
- * Output is the per-sample overlap series.  `seed` must be
- * non-zero.
+ * Output is the per-sample overlap series.  The PRNG is
+ * seeded from `seed` verbatim, identically on every rank;
+ * any value is valid, including 0.
  */
 
 struct cmpsit_data {
@@ -33,7 +34,7 @@ struct cmpsit_data {
 	size_t depth;		/* randomised term count per step */
 	double angle_det;	/* deterministic step size */
 	double angle_rand;	/* randomised step size */
-	uint64_t seed;		/* PRNG seed; must be non-zero */
+	uint64_t seed;		/* PRNG seed; used verbatim */
 };
 
 /* Working state for one sampled composite circuit. */

--- a/include/circ/qdrift.h
+++ b/include/circ/qdrift.h
@@ -20,16 +20,16 @@
  * in draw order.  Output is the per-sample overlap
  * <psi|U|psi>.
  *
- * The PRNG is xoshiro256** seeded by `seed` and split
- * deterministically across MPI ranks; `seed` must be
- * non-zero.
+ * The PRNG is xoshiro256** seeded by `seed`, identically
+ * on every rank: all ranks must draw the same terms.  Any
+ * seed value is valid, including 0.
  */
 
 struct qdrift_data {
 	size_t samples;		/* number of independent samples */
 	size_t depth;		/* terms drawn per sample */
 	double step_size;	/* qDRIFT step size */
-	uint64_t seed;		/* PRNG seed; must be non-zero */
+	uint64_t seed;		/* PRNG seed; used verbatim */
 };
 
 struct qdrift_ranct {

--- a/include/xoshiro256ss.h
+++ b/include/xoshiro256ss.h
@@ -25,6 +25,11 @@ struct xoshiro256ss {
 	uint64_t s[4];
 };
 
+/*
+ * Any 64-bit seed is valid, including 0: the state is expanded
+ * from the seed via a splitmix64 chain (never seeded raw), so
+ * the all-zero fixed point is unreachable.
+ */
 void xoshiro256ss_init(struct xoshiro256ss *rng, uint64_t seed);
 
 uint64_t xoshiro256ss_next(struct xoshiro256ss *rng);

--- a/test/t-cmpsit.c
+++ b/test/t-cmpsit.c
@@ -3,11 +3,13 @@
  * (partially-randomised) 2nd-order Trotter
  * (circ/cmpsit.c).
  *
- * Single scenario today: seed reproducibility.  Two
- * cmpsit_simul runs with identical cmpsit_data.seed must
- * produce bit-identical per-sample overlaps.  Pins the
- * RNG seed contract -- the same seed must drive the same
- * sample sequence across all `samples` draws.
+ * Scenarios: seed reproducibility (two cmpsit_simul runs
+ * with identical cmpsit_data.seed must produce
+ * bit-identical per-sample overlaps -- the same seed must
+ * drive the same sample sequence across all `samples`
+ * draws) and the seed-0 contract (0 is a legal value used
+ * verbatim, not poisoned by an earlier explicit-seed
+ * instance).
  *
  * Mean-convergence checks against a trotter / trott2
  * reference are the natural next step once a clean
@@ -148,12 +150,79 @@ static void t_seed_reproducible(void)
 }
 
 
+static void t_seed_zero(void)
+{
+	struct circ_hamil hm_master = build_hamil(NUM_TERMS);
+	struct circ_muldet md_master = build_muldet(NUM_DETS);
+
+	/* Poison attempt: an earlier instance with an explicit
+	 * seed must not leak into a later seed-0 init. */
+	const struct cmpsit_data dt_x = {
+		.samples = 1,
+		.steps = 1,
+		.length = 2,
+		.depth = 4,
+		.angle_det = 0.1,
+		.angle_rand = 0.1,
+		.seed = UINT64_C(0x18f4d20c7ab9635e),
+	};
+	struct cmpsit x;
+	struct circ_hamil hm_x = clone_hamil(&hm_master);
+	struct circ_muldet md_x = clone_muldet(&md_master);
+	TEST_EQ(cmpsit_init(&x, &dt_x, hm_x, STPREP_MULTIDET, &md_x, NULL),
+		0);
+	cmpsit_free(&x);
+
+	const struct cmpsit_data dt = {
+		.samples = 3,
+		.steps = 2,
+		.length = 2,
+		.depth = 4,
+		.angle_det = 0.1,
+		.angle_rand = 0.1,
+		.seed = 0,
+	};
+
+	struct cmpsit a, b;
+	struct circ_hamil hm_a = clone_hamil(&hm_master);
+	struct circ_muldet md_a = clone_muldet(&md_master);
+	TEST_EQ(cmpsit_init(&a, &dt, hm_a, STPREP_MULTIDET, &md_a, NULL),
+		0);
+	TEST_EQ(a.dt.seed, (uint64_t)0);
+	struct circ_hamil hm_b = clone_hamil(&hm_master);
+	struct circ_muldet md_b = clone_muldet(&md_master);
+	TEST_EQ(cmpsit_init(&b, &dt, hm_b, STPREP_MULTIDET, &md_b, NULL),
+		0);
+
+	TEST_EQ(cmpsit_simul(&a), 0);
+	TEST_EQ(cmpsit_simul(&b), 0);
+
+	for (size_t i = 0; i < a.ct.vals.len; i++) {
+		const _Complex double za = a.ct.vals.z[i];
+		const _Complex double zb = b.ct.vals.z[i];
+		TEST_ASSERT(isfinite(creal(za)) && isfinite(cimag(za)),
+			"sample %zu not finite: (%g+%gi)",
+			i, creal(za), cimag(za));
+		TEST_ASSERT(za == zb,
+			"sample %zu diverges: a=(%g+%gi) b=(%g+%gi)",
+			i, creal(za), cimag(za), creal(zb), cimag(zb));
+	}
+
+	cmpsit_free(&a);
+	cmpsit_free(&b);
+
+	circ_hamil_free(&hm_master);
+	circ_muldet_free(&md_master);
+}
+
+
 int main(void)
 {
 	world_init(nullptr, nullptr, WD_SEED);
 	xoshiro256ss_init(&RNG, RNG_SEED);
 
 	t_seed_reproducible();
+	t_seed_zero();
 
 	world_free();
 	return 0;

--- a/test/t-qdrift.c
+++ b/test/t-qdrift.c
@@ -2,13 +2,23 @@
  * t-qdrift -- correctness checks for the qDRIFT
  * randomised product formula (circ/qdrift.c).
  *
- * Two scenarios:
+ * Scenarios:
  *
  *   t_seed_reproducible    Two qdrift_simul runs with
  *                          identical seeds must produce
  *                          bit-identical per-sample
  *                          overlaps.  Pins the RNG seed
  *                          contract.
+ *
+ *   t_xoshiro_seed_zero    Seed 0 must yield a healthy
+ *                          generator: the state expands
+ *                          through splitmix64, never raw.
+ *
+ *   t_seed_zero            Seed 0 is a legal value used
+ *                          verbatim: init keeps it, the
+ *                          simulation runs, and it is not
+ *                          poisoned by an earlier
+ *                          explicit-seed instance.
  *
  *   t_single_term_eq_trott Single-term Hamiltonian: every
  *                          qdrift draw selects the same
@@ -152,6 +162,79 @@ static void t_seed_reproducible(void)
 	circ_muldet_free(&md_master);
 }
 
+static void t_xoshiro_seed_zero(void)
+{
+	/* A raw all-zero state is the generator's fixed point;
+	 * init must never produce it, for any seed.  Seed 0 is
+	 * the suspicious case. */
+	struct xoshiro256ss r;
+	xoshiro256ss_init(&r, 0);
+	TEST_ASSERT(r.s[0] || r.s[1] || r.s[2] || r.s[3],
+		"all-zero state from seed 0");
+	const uint64_t d0 = xoshiro256ss_next(&r);
+	const uint64_t d1 = xoshiro256ss_next(&r);
+	TEST_ASSERT(d0 != d1, "constant output from seed 0");
+}
+
+static void t_seed_zero(void)
+{
+	struct circ_hamil hm_master = build_hamil(NUM_TERMS);
+	struct circ_muldet md_master = build_muldet(NUM_DETS);
+
+	/* Poison attempt: an earlier instance with an explicit
+	 * seed must not leak into a later seed-0 init. */
+	const struct qdrift_data dt_x = {
+		.samples = 1,
+		.depth = 4,
+		.step_size = 0.1,
+		.seed = UINT64_C(0x5be6c30a97d1428f),
+	};
+	struct qdrift x;
+	struct circ_hamil hm_x = clone_hamil(&hm_master);
+	struct circ_muldet md_x = clone_muldet(&md_master);
+	TEST_EQ(qdrift_init(&x, &dt_x, hm_x, STPREP_MULTIDET, &md_x, NULL),
+		0);
+	qdrift_free(&x);
+
+	const struct qdrift_data dt = {
+		.samples = 4,
+		.depth = 8,
+		.step_size = 0.1,
+		.seed = 0,
+	};
+
+	struct qdrift a, b;
+	struct circ_hamil hm_a = clone_hamil(&hm_master);
+	struct circ_muldet md_a = clone_muldet(&md_master);
+	TEST_EQ(qdrift_init(&a, &dt, hm_a, STPREP_MULTIDET, &md_a, NULL),
+		0);
+	TEST_EQ(a.dt.seed, (uint64_t)0);
+	struct circ_hamil hm_b = clone_hamil(&hm_master);
+	struct circ_muldet md_b = clone_muldet(&md_master);
+	TEST_EQ(qdrift_init(&b, &dt, hm_b, STPREP_MULTIDET, &md_b, NULL),
+		0);
+
+	TEST_EQ(qdrift_simul(&a), 0);
+	TEST_EQ(qdrift_simul(&b), 0);
+
+	for (size_t i = 0; i < a.ct.vals.len; i++) {
+		const _Complex double za = a.ct.vals.z[i];
+		const _Complex double zb = b.ct.vals.z[i];
+		TEST_ASSERT(isfinite(creal(za)) && isfinite(cimag(za)),
+			"sample %zu not finite: (%g+%gi)",
+			i, creal(za), cimag(za));
+		TEST_ASSERT(za == zb,
+			"sample %zu diverges: a=(%g+%gi) b=(%g+%gi)",
+			i, creal(za), cimag(za), creal(zb), cimag(zb));
+	}
+
+	qdrift_free(&a);
+	qdrift_free(&b);
+
+	circ_hamil_free(&hm_master);
+	circ_muldet_free(&md_master);
+}
+
 static void t_single_term_eq_trott(void)
 {
 	/* Single-term Hamiltonian H = +1 * P.  qdrift always
@@ -223,6 +306,8 @@ int main(void)
 	xoshiro256ss_init(&RNG, RNG_SEED);
 
 	t_seed_reproducible();
+	t_xoshiro_seed_zero();
+	t_seed_zero();
 	t_single_term_eq_trott();
 
 	world_free();


### PR DESCRIPTION
qdrift and cmpsit each kept a mutable file-static `SEED`: an explicit seed overwrote it, seed 0 read it back as a fallback. Non-reentrant, and an explicit-seed instance poisoned the next seed-0 init — the same globals-leak class the circ cache was de-globalised for.

Seed 0 needs no special case: `xoshiro256ss_init` expands every seed through a splitmix64 chain (never raw state), so the all-zero fixed point is unreachable and 0 is as good a seed as any. The seed is now used verbatim; the header contracts drop the "must be non-zero" clause, and `qdrift.h` loses the stale per-rank-split claim (#49's world.h fix, same falsehood).

TDD: new `t_seed_zero` scenarios in t-qdrift/t-cmpsit failed on the cross-instance leak pre-fix; `t_xoshiro_seed_zero` pins the degenerate-state guard directly. Backward compatible: ph2run defaults both seeds to 1, explicit-seed streams unchanged, recorded worksheets replay via their stored seed attribute.

🤖 Generated with Claude Code